### PR TITLE
move portRange interface to eval pkg, add Connection interface to eva…

### DIFF
--- a/pkg/netpol/connlist/connlist.go
+++ b/pkg/netpol/connlist/connlist.go
@@ -29,19 +29,8 @@ type Peer2PeerConnection interface {
 	// AllProtocolsAndPorts returns true if all ports are allowed for all protocols
 	AllProtocolsAndPorts() bool
 	// ProtocolsAndPorts returns the set of allowed connections
-	ProtocolsAndPorts() map[v1.Protocol][]PortRange
+	ProtocolsAndPorts() map[v1.Protocol][]eval.PortRange
 	// String returns a string representation of the connection object
-	String() string
-}
-
-// PortRange describes a port or a range of ports for allowed traffic
-// If start port equals end port, it represents a single port
-type PortRange interface {
-	// Start is the start port
-	Start() int64
-	// End is the end port
-	End() int64
-	// String returns a string representation of the PortRange object
 	String() string
 }
 
@@ -53,7 +42,7 @@ type connection struct {
 	src               eval.Peer
 	dst               eval.Peer
 	allConnections    bool
-	protocolsAndPorts map[v1.Protocol][]portRange
+	protocolsAndPorts map[v1.Protocol][]eval.PortRange
 }
 
 func (c *connection) Src() eval.Peer {
@@ -65,15 +54,8 @@ func (c *connection) Dst() eval.Peer {
 func (c *connection) AllProtocolsAndPorts() bool {
 	return c.allConnections
 }
-func (c *connection) ProtocolsAndPorts() map[v1.Protocol][]PortRange {
-	res := make(map[v1.Protocol][]PortRange, len(c.protocolsAndPorts))
-	for protocol, ports := range c.protocolsAndPorts {
-		res[protocol] = make([]PortRange, len(ports))
-		for i := range ports {
-			res[protocol][i] = &ports[i]
-		}
-	}
-	return res
+func (c *connection) ProtocolsAndPorts() map[v1.Protocol][]eval.PortRange {
+	return c.protocolsAndPorts
 }
 
 // return a string representation for a connection object
@@ -94,27 +76,6 @@ func (c *connection) String() string {
 		connStr = strings.Join(connStrings, connsAndPortRangeSeparator)
 	}
 	return fmt.Sprintf("%s => %s : %s", c.Src().String(), c.Dst().String(), connStr)
-}
-
-// portRange implements the PortRange interface
-type portRange struct {
-	start int64
-	end   int64
-}
-
-func (pr *portRange) Start() int64 {
-	return pr.start
-}
-func (pr *portRange) End() int64 {
-	return pr.end
-}
-
-// return a string representation for a portRange object
-func (pr *portRange) String() string {
-	if pr.End() != pr.Start() {
-		return fmt.Sprintf("%d-%d", pr.Start(), pr.End())
-	}
-	return fmt.Sprintf("%d", pr.Start())
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -212,21 +173,11 @@ func getConnectionsList(pe *eval.PolicyEngine) ([]Peer2PeerConnection, error) {
 			if allowedConnections.IsEmpty() {
 				continue
 			}
-			protocolsMap := allowedConnections.GetProtocolsAndPortsMap()
 			connectionObj := &connection{
 				src:               srcPeer,
 				dst:               dstPeer,
-				allConnections:    allowedConnections.AllowAll,
-				protocolsAndPorts: make(map[v1.Protocol][]portRange, len(protocolsMap)),
-			}
-			// convert each port range (list) to connlist.Port
-			for protocol, ports := range protocolsMap {
-				connectionObj.protocolsAndPorts[protocol] = make([]portRange, len(ports))
-				for i := range ports {
-					startPort, endPort := ports[i][0], ports[i][1]
-					port := portRange{start: startPort, end: endPort}
-					connectionObj.protocolsAndPorts[protocol][i] = port
-				}
+				allConnections:    allowedConnections.AllConnections(),
+				protocolsAndPorts: allowedConnections.ProtocolsAndPortsMap(),
 			}
 			res = append(res, connectionObj)
 		}
@@ -245,7 +196,7 @@ func ConnectionsListToString(conns []Peer2PeerConnection) string {
 }
 
 // get string representation for a list of port ranges
-func portsString(ports []PortRange) string {
+func portsString(ports []eval.PortRange) string {
 	portsStr := make([]string, len(ports))
 	for i := range ports {
 		portsStr[i] = ports[i].String()

--- a/pkg/netpol/connlist/connlist.go
+++ b/pkg/netpol/connlist/connlist.go
@@ -16,9 +16,9 @@ import (
 	"github.com/np-guard/netpol-analyzer/pkg/netpol/scan"
 )
 
-const (
-	connsAndPortRangeSeparator = ","
-)
+// The connlist package allows producing a k8s connectivity report based on network policies.
+// It lists the set of allowed connections between each pair of peers (pods or ip-blocks).
+// The resources can be extracted from a directory containing YAML manifests, or from a k8s cluster.
 
 // Peer2PeerConnection encapsulates the allowed connectivity result between two peers.
 type Peer2PeerConnection interface {
@@ -36,6 +36,10 @@ type Peer2PeerConnection interface {
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 // internal type definitions below
+
+const (
+	connsAndPortRangeSeparator = ","
+)
 
 // connection implements the Peer2PeerConnection interface
 type connection struct {

--- a/pkg/netpol/eval/connection.go
+++ b/pkg/netpol/eval/connection.go
@@ -1,0 +1,65 @@
+package eval
+
+import (
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/np-guard/netpol-analyzer/pkg/netpol/eval/internal/k8s"
+)
+
+// Connection represents a set of allowed connections between two peers
+type Connection interface {
+	// ProtocolsAndPortsMap returns the set of allowed connections
+	ProtocolsAndPortsMap() map[v1.Protocol][]PortRange
+	// AllConnections returns true if all ports are allowed for all protocols
+	AllConnections() bool
+	// IsEmpty returns true if no connection is allowed
+	IsEmpty() bool
+}
+
+// PortRange describes a port or a range of ports for allowed traffic
+// If start port equals end port, it represents a single port
+type PortRange interface {
+	// Start is the start port
+	Start() int64
+	// End is the end port
+	End() int64
+	// String returns a string representation of the PortRange object
+	String() string
+}
+
+// k8sConnectionSetWrapper implements the Connection interface
+type k8sConnectionSetWrapper struct {
+	protocolsAndPortsMap map[v1.Protocol][]PortRange
+	connectionSet        k8s.ConnectionSet
+}
+
+func (c *k8sConnectionSetWrapper) ProtocolsAndPortsMap() map[v1.Protocol][]PortRange {
+	return c.protocolsAndPortsMap
+}
+
+func (c *k8sConnectionSetWrapper) AllConnections() bool {
+	return c.connectionSet.AllowAll
+}
+func (c *k8sConnectionSetWrapper) IsEmpty() bool {
+	return c.connectionSet.IsEmpty()
+}
+
+func (c *k8sConnectionSetWrapper) ConnectionSet() k8s.ConnectionSet {
+	return c.connectionSet
+}
+
+// convert an input k8s.ConnectionSet object to a connectionObj that implements Connection interface
+func getConnectionObject(conn k8s.ConnectionSet) Connection {
+	protocolsMap := conn.ProtocolsAndPortsMap()
+	res := &k8sConnectionSetWrapper{
+		protocolsAndPortsMap: make(map[v1.Protocol][]PortRange, len(protocolsMap)),
+		connectionSet:        conn,
+	}
+	for protocol, ports := range protocolsMap {
+		res.protocolsAndPortsMap[protocol] = make([]PortRange, len(ports))
+		for i, portRange := range ports {
+			res.protocolsAndPortsMap[protocol][i] = portRange
+		}
+	}
+	return res
+}


### PR DESCRIPTION
…l, change returned type of AllAllowedConnectionsBetweenPeers, simplify connlist

Handle issue #50 : fourth item - ConnectionSet.GetProtocolsAndPortsMap() : return explicit type of port range.
Defining the PortRange interface at package eval.
