### PR TITLE
excluding tag version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,3 +54,5 @@ require (
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
+
+exclude github.com/openshift/api v3.9.0+incompatible


### PR DESCRIPTION
I found this:
`exclude `and` replace` directives only operate on the current (“main”) module. exclude and replace directives in modules other than the main module are ignored when building the main module. **The replace and exclude statements, therefore, allow the main module complete control over its own build**, without also being subject to complete control by dependencies. 

may this "tell" the `dependapot` not to try to upgrade the `openshift/api` package to the tagged one