### PR TITLE
refactoring cmd pkg to eliminate use of init functions

### DIFF
--- a/cmd/netpolicy/cmd/command_test.go
+++ b/cmd/netpolicy/cmd/command_test.go
@@ -53,6 +53,7 @@ func postTestRun(isErr bool) string {
 func runTest(test cmdTest, t *testing.T) {
 	// run the test and get its output
 	preTestRun()
+	rootCmd := newCommandRoot()
 	rootCmd.SetArgs(test.args)
 	err := rootCmd.Execute()
 	if !test.isErr {

--- a/cmd/netpolicy/cmd/evaluate.go
+++ b/cmd/netpolicy/cmd/evaluate.go
@@ -43,162 +43,184 @@ var (
 	port           string
 )
 
-// evaluateCmd represents the evaluate command
-var evaluateCmd = &cobra.Command{
-	Use:     "evaluate",
-	Short:   "Evaluate if a specific connection allowed",
-	Aliases: []string{"eval", "check", "allow"}, // TODO: close on fewer, consider changing command name?
-	Example: `  # Evaluate if a specific connection is allowed on given resources from dir path
-  k8snetpolicy eval --dirpath ./resources_dir/ -s pod-1 -d pod-2 -p 80
-  
-  # Evaluate if a specific connection is allowed on a live k8s cluster
-  k8snetpolicy eval -k ./kube/config -s pod-1 -d pod-2 -p 80`,
+func validateEvalFlags() error {
+	// Validate flags values
+	if sourcePod.Name == "" && srcExternalIP == "" {
+		return errors.New("no source defined, source pod and namespace or external IP required")
+	} else if sourcePod.Name != "" && srcExternalIP != "" {
+		return errors.New("only one of source pod and namespace or external IP can be defined, not both")
+	}
 
-	// TODO: can this check be done in an Args function (e.g., incl. built-in's such as MinArgs(3))?
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+	if destinationPod.Name == "" && dstExternalIP == "" {
+		return errors.New("no destination defined, destination pod and namespace or external IP required")
+	} else if destinationPod.Name != "" && dstExternalIP != "" {
+		return errors.New("only one of destination pod and namespace or external IP can be defined, not both")
+	}
 
-		// Validate flags values
-		if sourcePod.Name == "" && srcExternalIP == "" {
-			return errors.New("no source defined, source pod and namespace or external IP required")
-		} else if sourcePod.Name != "" && srcExternalIP != "" {
-			return errors.New("only one of source pod and namespace or external IP can be defined, not both")
+	if srcExternalIP != "" && dstExternalIP == "" {
+		return errors.New("only one of source or destination can be defined as external IP, not both")
+	}
+
+	if port == "" {
+		return errors.New("destination port name or value is required")
+	}
+	return nil
+}
+
+func updatePolicyEngineObjectsFromDirPath(pe *eval.PolicyEngine, podNames []types.NamespacedName) error {
+	// get relevant resources from dir path
+	scanner := scan.NewResourcesScanner(logger.NewDefaultLogger(), false, filepath.WalkDir)
+	objectsList, processingErrs := scanner.FilesToObjectsListFiltered(dirPath, podNames)
+	for _, err := range processingErrs {
+		if err.IsFatal() || err.IsSevere() {
+			return fmt.Errorf("scan dir path %s had processing errors: %v", dirPath, err.Error())
 		}
+	}
 
-		if destinationPod.Name == "" && dstExternalIP == "" {
-			return errors.New("no destination defined, destination pod and namespace or external IP required")
-		} else if destinationPod.Name != "" && dstExternalIP != "" {
-			return errors.New("only one of destination pod and namespace or external IP can be defined, not both")
+	var err error
+	for _, obj := range objectsList {
+		switch obj.Kind {
+		case scan.Pod:
+			err = pe.UpsertObject(obj.Pod)
+		case scan.Namespace:
+			err = pe.UpsertObject(obj.Namespace)
+		case scan.Networkpolicy:
+			err = pe.UpsertObject(obj.Networkpolicy)
+		default:
+			continue
 		}
-
-		if srcExternalIP != "" && dstExternalIP == "" {
-			return errors.New("only one of source or destination can be defined as external IP, not both")
+		if err != nil {
+			return err
 		}
+	}
+	return nil
+}
 
-		if port == "" {
-			return errors.New("destination port name or value is required")
+func updatePolicyEngineObjectsFromLiveCluster(pe *eval.PolicyEngine, podNames []types.NamespacedName, nsNames []string) error {
+	// get relevant resources from k8s live cluster
+	const ctxTimeoutSeconds = 3
+	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutSeconds*time.Second)
+	defer cancel()
+
+	for _, name := range nsNames {
+		ns, apierr := clientset.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
+		if apierr != nil {
+			return apierr
 		}
+		if err := pe.UpsertObject(ns); err != nil {
+			return err
+		}
+	}
 
-		// Call parent pre-run
-		if rootCmd.PersistentPreRunE != nil {
-			if err := rootCmd.PersistentPreRunE(cmd, args); err != nil {
+	for _, name := range podNames {
+		pod, apierr := clientset.CoreV1().Pods(name.Namespace).Get(ctx, name.Name, metav1.GetOptions{})
+		if apierr != nil {
+			return apierr
+		}
+		if err := pe.UpsertObject(pod); err != nil {
+			return err
+		}
+	}
+
+	for _, ns := range nsNames {
+		npList, apierr := clientset.NetworkingV1().NetworkPolicies(ns).List(ctx, metav1.ListOptions{})
+		if apierr != nil {
+			return apierr
+		}
+		for i := range npList.Items {
+			if err := pe.UpsertObject(&npList.Items[i]); err != nil {
 				return err
 			}
 		}
+	}
+	return nil
+}
 
-		return nil
-	},
+func runEvalCommand() error {
+	nsNames := []string{}
+	podNames := []types.NamespacedName{}
 
-	RunE: func(cmd *cobra.Command, args []string) error {
-		nsNames := []string{}
-		podNames := []types.NamespacedName{}
+	destination := dstExternalIP
+	if destination == "" {
+		destination = destinationPod.String()
+		nsNames = append(nsNames, destinationPod.Namespace)
+		podNames = append(podNames, destinationPod)
+	}
 
-		destination := dstExternalIP
-		if destination == "" {
-			destination = destinationPod.String()
-			nsNames = append(nsNames, destinationPod.Namespace)
-			podNames = append(podNames, destinationPod)
+	source := srcExternalIP
+	if source == "" {
+		source = sourcePod.String()
+		nsNames = append(nsNames, sourcePod.Namespace)
+		podNames = append(podNames, sourcePod)
+	}
+
+	pe := eval.NewPolicyEngine()
+
+	if dirPath != "" {
+		if err := updatePolicyEngineObjectsFromDirPath(pe, podNames); err != nil {
+			return err
 		}
 
-		source := srcExternalIP
-		if source == "" {
-			source = sourcePod.String()
-			nsNames = append(nsNames, sourcePod.Namespace)
-			podNames = append(podNames, sourcePod)
+	} else {
+		if err := updatePolicyEngineObjectsFromLiveCluster(pe, podNames, nsNames); err != nil {
+			return err
 		}
+	}
 
-		pe := eval.NewPolicyEngine()
+	allowed, err := pe.CheckIfAllowed(source, destination, protocol, port)
+	if err != nil {
+		return err
+	}
 
-		if dirPath != "" {
-			// get relevant resources from dir path
-			scanner := scan.NewResourcesScanner(logger.NewDefaultLogger(), false, filepath.WalkDir)
-			objectsList, processingErrs := scanner.FilesToObjectsListFiltered(dirPath, podNames)
-			for _, err := range processingErrs {
-				if err.IsFatal() || err.IsSevere() {
-					return fmt.Errorf("scan dir path %s had processing errors: %v", dirPath, err.Error())
-				}
+	// @todo: use a logger instead?
+	fmt.Printf("%v => %v over %s/%s: %t\n", source, destination, protocol, port, allowed)
+	return nil
+}
+
+// newCommandEvaluate returns a cobra command with the appropriate configuration and flags to run evaluate command
+func newCommandEvaluate() *cobra.Command {
+	c := &cobra.Command{
+		Use:     "evaluate",
+		Short:   "Evaluate if a specific connection allowed",
+		Aliases: []string{"eval", "check", "allow"}, // TODO: close on fewer, consider changing command name?
+		Example: `  # Evaluate if a specific connection is allowed on given resources from dir path
+	k8snetpolicy eval --dirpath ./resources_dir/ -s pod-1 -d pod-2 -p 80
+	
+	# Evaluate if a specific connection is allowed on a live k8s cluster
+	k8snetpolicy eval -k ./kube/config -s pod-1 -d pod-2 -p 80`,
+
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateEvalFlags(); err != nil {
+				return err
 			}
-
-			var err error
-			for _, obj := range objectsList {
-				if obj.Kind == scan.Pod {
-					err = pe.UpsertObject(obj.Pod)
-				} else if obj.Kind == scan.Namespace {
-					err = pe.UpsertObject(obj.Namespace)
-				} else if obj.Kind == scan.Networkpolicy {
-					err = pe.UpsertObject(obj.Networkpolicy)
-				}
-				if err != nil {
-					return err
-				}
-			}
-
-		} else {
-			// get relevant resources from k8s live cluster
-			var err error
-			const ctxTimeoutSeconds = 3
-			ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutSeconds*time.Second)
-			defer cancel()
-
-			for _, name := range nsNames {
-				ns, apierr := clientset.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
-				if apierr != nil {
-					return apierr
-				}
-				if err = pe.UpsertObject(ns); err != nil {
-					return err
-				}
-			}
-
-			for _, name := range podNames {
-				pod, apierr := clientset.CoreV1().Pods(name.Namespace).Get(ctx, name.Name, metav1.GetOptions{})
-				if apierr != nil {
-					return apierr
-				}
-				if err = pe.UpsertObject(pod); err != nil {
-					return err
-				}
-			}
-
-			for _, ns := range nsNames {
-				npList, apierr := clientset.NetworkingV1().NetworkPolicies(ns).List(ctx, metav1.ListOptions{})
-				if apierr != nil {
-					return apierr
-				}
-				for i := range npList.Items {
-					if err = pe.UpsertObject(&npList.Items[i]); err != nil {
+			// call parent pre-run
+			if parent := cmd.Parent(); parent != nil {
+				if parent.PersistentPreRunE != nil {
+					if err := parent.PersistentPreRunE(cmd, args); err != nil {
 						return err
 					}
 				}
 			}
-		}
+			return nil
+		},
 
-		allowed, err := pe.CheckIfAllowed(source, destination, protocol, port)
-		if err != nil {
-			return err
-		}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := runEvalCommand(); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
 
-		// @todo: use a logger instead?
-		fmt.Printf("%v => %v over %s/%s: %t\n", source, destination, protocol, port, allowed)
-		return nil
-	},
-}
+	// add flags
+	c.Flags().StringVarP(&sourcePod.Name, "source-pod", "s", sourcePod.Name, "Source pod name, required")
+	c.Flags().StringVarP(&sourcePod.Namespace, "source-namespace", "n", sourcePod.Namespace, "Source pod namespace")
+	c.Flags().StringVarP(&destinationPod.Name, "destination-pod", "d", destinationPod.Name, "Destination pod name")
+	c.Flags().StringVarP(&destinationPod.Namespace, "destination-namespace", "", destinationPod.Namespace, "Destination pod namespace")
+	c.Flags().StringVarP(&srcExternalIP, "source-ip", "", srcExternalIP, "Source (external) IP address")
+	c.Flags().StringVarP(&dstExternalIP, "destination-ip", "", dstExternalIP, "Destination (external) IP address")
+	c.Flags().StringVarP(&port, "destination-port", "p", port, "Destination port (name or number)")
+	c.Flags().StringVarP(&protocol, "protocol", "", protocol, "Protocol in use (tcp, udp, sctp)")
 
-func init() {
-	rootCmd.AddCommand(evaluateCmd)
-
-	// connection definition
-	evaluateCmd.Flags().StringVarP(&sourcePod.Name, "source-pod", "s",
-		sourcePod.Name, "Source pod name, required")
-	evaluateCmd.Flags().StringVarP(&sourcePod.Namespace, "source-namespace", "n",
-		sourcePod.Namespace, "Source pod namespace")
-	evaluateCmd.Flags().StringVarP(&destinationPod.Name, "destination-pod", "d",
-		destinationPod.Name, "Destination pod name")
-	evaluateCmd.Flags().StringVarP(&destinationPod.Namespace, "destination-namespace", "",
-		destinationPod.Namespace, "Destination pod namespace")
-	evaluateCmd.Flags().StringVarP(&srcExternalIP, "source-ip", "",
-		srcExternalIP, "Source (external) IP address")
-	evaluateCmd.Flags().StringVarP(&dstExternalIP, "destination-ip", "",
-		dstExternalIP, "Destination (external) IP address")
-	evaluateCmd.Flags().StringVarP(&port, "destination-port", "p", port, "Destination port (name or number)")
-	evaluateCmd.Flags().StringVarP(&protocol, "protocol", "", protocol, "Protocol in use (tcp, udp, sctp)")
+	return c
 }

--- a/cmd/netpolicy/cmd/list.go
+++ b/cmd/netpolicy/cmd/list.go
@@ -28,66 +28,71 @@ var (
 	output string
 )
 
-// listCmd represents the list command
-var listCmd = &cobra.Command{
-	Use:   "list",
-	Short: "Lists all allowed connections",
-	Long: `Lists all allowed connections based on the workloads and network policies
+func runListCommand() error {
+	var conns []connlist.Peer2PeerConnection
+	var err error
+
+	analyzer := connlist.NewConnlistAnalyzer(connlist.WithFocusWorkload(focusWorkload), connlist.WithOutputFormat(output))
+
+	if dirPath != "" {
+		conns, err = analyzer.ConnlistFromDirPath(dirPath)
+	} else {
+		conns, err = analyzer.ConnlistFromK8sCluster(clientset)
+	}
+	if err != nil {
+		return err
+	}
+	out, err := analyzer.ConnectionsListToString(conns)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s", out)
+
+	return nil
+}
+
+// newCommandList returns a cobra command with the appropriate configuration and flags to run list command
+func newCommandList() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "list",
+		Short: "Lists all allowed connections",
+		Long: `Lists all allowed connections based on the workloads and network policies
 defined`,
-	Example: `  # Get list of allowed connections from resources dir path
+		Example: `  # Get list of allowed connections from resources dir path
   k8snetpolicy list --dirpath ./resources_dir/ 
   
   # Get list of allowed connections from live k8s cluster
   k8snetpolicy list -k ./kube/config`,
 
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-
-		if err := connlist.ValidateOutputFormat(output); err != nil {
-			return err
-		}
-		// call parent pre-run
-		if rootCmd.PersistentPreRunE != nil {
-			if err := rootCmd.PersistentPreRunE(cmd, args); err != nil {
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := connlist.ValidateOutputFormat(output); err != nil {
 				return err
 			}
-		}
-		return nil
-	},
+			// call parent pre-run
+			if parent := cmd.Parent(); parent != nil {
+				if parent.PersistentPreRunE != nil {
+					if err := parent.PersistentPreRunE(cmd, args); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		},
 
-	RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := runListCommand(); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
 
-		var conns []connlist.Peer2PeerConnection
-		var err error
-
-		analyzer := connlist.NewConnlistAnalyzer(connlist.WithFocusWorkload(focusWorkload), connlist.WithOutputFormat(output))
-
-		if dirPath != "" {
-			conns, err = analyzer.ConnlistFromDirPath(dirPath)
-		} else {
-			conns, err = analyzer.ConnlistFromK8sCluster(clientset)
-		}
-		if err != nil {
-			return err
-		}
-		out, err := analyzer.ConnectionsListToString(conns)
-		if err != nil {
-			return err
-		}
-		fmt.Printf("%s", out)
-
-		return nil
-	},
-}
-
-// define any flags and configuration settings.
-// Use PersistentFlags() for flags inherited by subcommands or Flags() for local flags.
-func init() {
-	rootCmd.AddCommand(listCmd)
-
-	// output options
-	listCmd.Flags().StringVarP(&focusWorkload, "focusworkload", "",
-		focusWorkload, "Focus connections of specified workload name in the output")
+	// define any flags and configuration settings.
+	// Use PersistentFlags() for flags inherited by subcommands or Flags() for local flags.
+	c.Flags().StringVarP(&focusWorkload, "focusworkload", "", "", "Focus connections of specified workload name in the output")
 	// output format - default txt
 	supportedFormats := strings.Join(connlist.ValidFormats, ",")
-	listCmd.Flags().StringVarP(&output, "output", "o", connlist.DefaultFormat, "Required output format ("+supportedFormats+")")
+	c.Flags().StringVarP(&output, "output", "o", connlist.DefaultFormat, "Required output format ("+supportedFormats+")")
+
+	return c
 }

--- a/cmd/netpolicy/cmd/root.go
+++ b/cmd/netpolicy/cmd/root.go
@@ -31,59 +31,63 @@ var (
 	clientset *kubernetes.Clientset
 )
 
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:   "k8snetpolicy",
-	Short: "Determine allowed connection based on Kubernetes NetworkPolicy objects",
+// newCommandRoot returns a cobra command with the appropriate configuration, flags and sub-commands to run the root command k8snetpolicy
+func newCommandRoot() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "k8snetpolicy",
+		Short: "Determine allowed connection based on Kubernetes NetworkPolicy objects",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if dirPath != "" {
+				return nil
+			}
+			// TODO: add explicit logs to indicate progress (loading config, listing namespaces, ...)
+			// TODO: use errors.Wrap for clearer error return?
 
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		if dirPath != "" {
+			// create a k8s client with the correct config and context
+			loadingRules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig}
+			overrides := &clientcmd.ConfigOverrides{}
+			if kubecontext != "" {
+				overrides.CurrentContext = kubecontext
+			}
+
+			k8sconf, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides).ClientConfig()
+			if err != nil {
+				return err
+			}
+			clientset, err = kubernetes.NewForConfig(k8sconf)
+			if err != nil {
+				return err
+			}
 			return nil
-		}
-		// TODO: add explicit logs to indicate progress (loading config, listing namespaces, ...)
-		// TODO: use errors.Wrap for clearer error return?
-
-		// create a k8s client with the correct config and context
-		loadingRules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig}
-		overrides := &clientcmd.ConfigOverrides{}
-		if kubecontext != "" {
-			overrides.CurrentContext = kubecontext
-		}
-
-		k8sconf, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides).ClientConfig()
-		if err != nil {
-			return err
-		}
-		clientset, err = kubernetes.NewForConfig(k8sconf)
-		if err != nil {
-			return err
-		}
-		return nil
-	},
-}
-
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
-		os.Exit(1)
+		},
 	}
-}
 
-// define any flags and configuration settings
-func init() {
+	// define any flags and configuration settings
 	// resources dir path
-	rootCmd.PersistentFlags().StringVarP(&dirPath, "dirpath", "",
-		dirPath, "Resources dir path when evaluating connections from a dir")
-
+	c.PersistentFlags().StringVarP(&dirPath, "dirpath", "", "", "Resources dir path when evaluating connections from a dir")
 	// cluster access
 	config := os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
 	if config == "" {
 		config = clientcmd.RecommendedHomeFile
 	}
-	rootCmd.PersistentFlags().StringVarP(&kubeconfig, clientcmd.RecommendedConfigPathFlag, "k", config,
+	c.PersistentFlags().StringVarP(&kubeconfig, clientcmd.RecommendedConfigPathFlag, "k", config,
 		"Path and file to use for kubeconfig when evaluating connections in a live cluster")
-	rootCmd.PersistentFlags().StringVarP(&kubecontext, clientcmd.FlagContext, "c", "",
+	c.PersistentFlags().StringVarP(&kubecontext, clientcmd.FlagContext, "c", "",
 		"Kubernetes context to use when evaluating connections in a live cluster")
+
+	// add sub-commands
+	c.AddCommand(newCommandEvaluate())
+	c.AddCommand(newCommandList())
+
+	return c
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	rootCmd := newCommandRoot()
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
this PR should be checked and approved after merging #139

the purpose of this PR is to eliminate using `func init`, so we can remove the `//nolint:gochecknoinits`