### PR TITLE
silent usage message if the error occurred when running a valid command

### DIFF
--- a/cmd/netpolicy/cmd/evaluate.go
+++ b/cmd/netpolicy/cmd/evaluate.go
@@ -206,6 +206,7 @@ func newCommandEvaluate() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := runEvalCommand(); err != nil {
+				cmd.SilenceUsage = true // don't print usage message when returning an error from running a valid command
 				return err
 			}
 			return nil

--- a/cmd/netpolicy/cmd/list.go
+++ b/cmd/netpolicy/cmd/list.go
@@ -84,6 +84,7 @@ defined`,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := runListCommand(); err != nil {
+				cmd.SilenceUsage = true // don't print usage message when returning an error from running a valid command
 				return err
 			}
 			return nil


### PR DESCRIPTION
#178 
the usage messages are printed automatically when an error is returned from (`cobra.command.Execute()`).
in order not to print the usage message, we need to use a `cobra.command.SilenceUsage` flag in the cases we want to silent it