### PR TITLE
issue 215 - fix errors appending bug

### DIFF
--- a/pkg/netpol/diff/diff_errors.go
+++ b/pkg/netpol/diff/diff_errors.go
@@ -16,10 +16,6 @@ type diffGeneratingError struct {
 	severe bool
 }
 
-type connectionsAnalyzingError struct {
-	origErr error
-}
-
 type resultFormattingError struct {
 	origErr error
 }
@@ -56,10 +52,6 @@ func (e *resultFormattingError) Error() string {
 	return e.origErr.Error()
 }
 
-func (e *connectionsAnalyzingError) Error() string {
-	return e.origErr.Error()
-}
-
 func (e *handlingIPpeersError) Error() string {
 	return e.origErr.Error()
 }
@@ -67,10 +59,6 @@ func (e *handlingIPpeersError) Error() string {
 // constructors
 func newResultFormattingError(err error) *diffGeneratingError {
 	return &diffGeneratingError{err: &resultFormattingError{err}, fatal: true, severe: false}
-}
-
-func newConnectionsAnalyzingError(err error, fatal, severe bool) *diffGeneratingError {
-	return &diffGeneratingError{err: &connectionsAnalyzingError{err}, fatal: fatal, severe: severe}
 }
 
 func newHandlingIPpeersError(err error) *diffGeneratingError {

--- a/tests/dirty/backend.yaml
+++ b/tests/dirty/backend.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  selector:
+    matchLabels:
+      app: backendservice
+  template:
+    metadata:
+      labels:
+        app: backendservice
+    spec:
+      containers:
+      - name: server
+        image: "{{ printf "%s" ._thing.image }}"
+        ports:
+        - containerPort: 9090
+        readinessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: "/_healthz"
+            port: 9090
+        livenessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: "/_healthz"
+            port: 9090
+        env:
+        - name: PORT
+          value: "9090"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backendservice
+spec:
+  type: ClusterIP
+  selector:
+    app: backendservice
+  ports:
+  - name: http
+    port: 9090
+    targetPort: 9090

--- a/tests/dirty/frontend.yaml
+++ b/tests/dirty/frontend.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: server
+        image: "{{ printf "%s" ._thing.image }}"
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: "/_healthz"
+            port: 8080
+        livenessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: "/_healthz"
+            port: 8080
+        env:
+        - name: PORT
+          value: "8080"
+        - name: BACKEND_SERVICE_ADDR
+          value: "backendservice:9090"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: frontend
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-external
+spec:
+  type: LoadBalancer
+  selector:
+    app: frontend
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080


### PR DESCRIPTION
the problem was : `connlistAnalyzer.Errors() `  after first call to `caAnalyzer.ConnlistFromDirPath(dirPath1)`, were appended twice into diffAnalyzer Errors list (once after each call to the ConnlistAnalyzer)
fix: errors returned by first call, should be appended only if we are returning from the `calling func`.
After finishing with all calls to the `connlistAnalyzer` , all `connlistAnalyzer.Errors()` are appended to the diffAnalyzer Errors list 

** also, added the example folder with malformed yamls
** I suggest adding a `--fail` flag to enable running `WithStopOnError` from cmd-line too (helps with local testing)
if it is acceptable, should be added with this PR or new one?
