### PR TITLE
wip - defining an interface for exposure-analysis results

### DIFF
--- a/pkg/cli/list.go
+++ b/pkg/cli/list.go
@@ -45,9 +45,9 @@ func runListCommand() error {
 	analyzer := connlist.NewConnlistAnalyzer(getConnlistOptions(clogger)...)
 
 	if dirPath != "" {
-		conns, _, err = analyzer.ConnlistFromDirPath(dirPath)
+		conns, _, _, err = analyzer.ConnlistFromDirPath(dirPath)
 	} else {
-		conns, _, err = analyzer.ConnlistFromK8sCluster(clientset)
+		conns, _, _, err = analyzer.ConnlistFromK8sCluster(clientset)
 	}
 	if err != nil {
 		return err

--- a/pkg/netpol/connlist/connlist_test.go
+++ b/pkg/netpol/connlist/connlist_test.go
@@ -77,7 +77,7 @@ func TestConnListFromDir(t *testing.T) {
 			t.Parallel()
 			for _, format := range tt.outputFormats {
 				pTest := prepareTest(tt.testDirName, tt.focusWorkload, format)
-				res, _, err := pTest.analyzer.ConnlistFromDirPath(pTest.dirPath)
+				res, _, _, err := pTest.analyzer.ConnlistFromDirPath(pTest.dirPath)
 				require.Nil(t, err, pTest.testInfo)
 				out, err := pTest.analyzer.ConnectionsListToString(res)
 				require.Nil(t, err, pTest.testInfo)
@@ -100,7 +100,7 @@ func TestConnListFromResourceInfos(t *testing.T) {
 				// require.Empty(t, errs, testInfo) - TODO: add info about expected errors
 				// from each test here (these errors do not stop the analysis or affect the output)
 				// more suitable to test this in a separate package (manifests) where  GetResourceInfosFromDirPath is implemented
-				res, _, err := pTest.analyzer.ConnlistFromResourceInfos(infos)
+				res, _, _, err := pTest.analyzer.ConnlistFromResourceInfos(infos)
 				require.Nil(t, err, pTest.testInfo)
 				out, err := pTest.analyzer.ConnectionsListToString(res)
 				require.Nil(t, err, pTest.testInfo)
@@ -193,9 +193,9 @@ func getAnalysisResFromAPI(apiName, dirName, focusWorkload string) (
 	switch apiName {
 	case ResourceInfosFunc:
 		infos, _ := fsscanner.GetResourceInfosFromDirPath([]string{pTest.dirPath}, true, false)
-		connsRes, peersRes, err = pTest.analyzer.ConnlistFromResourceInfos(infos)
+		connsRes, peersRes, _, err = pTest.analyzer.ConnlistFromResourceInfos(infos)
 	case DirPathFunc:
-		connsRes, peersRes, err = pTest.analyzer.ConnlistFromDirPath(pTest.dirPath)
+		connsRes, peersRes, _, err = pTest.analyzer.ConnlistFromDirPath(pTest.dirPath)
 	}
 	return pTest.analyzer, connsRes, peersRes, err
 }
@@ -447,7 +447,7 @@ func TestNotContainedOutputLines(t *testing.T) {
 // helping func - creates ConnlistAnalyzer with desired opts and returns the analyzer with connlist from provided directory
 func getConnlistFromDirPathRes(opts []ConnlistAnalyzerOption, dirName string) (*ConnlistAnalyzer, []Peer2PeerConnection, error) {
 	analyzer := NewConnlistAnalyzer(opts...)
-	res, _, err := analyzer.ConnlistFromDirPath(testutils.GetTestDirPath(dirName))
+	res, _, _, err := analyzer.ConnlistFromDirPath(testutils.GetTestDirPath(dirName))
 	return analyzer, res, err
 }
 
@@ -501,7 +501,7 @@ func TestConnlistOutputFatalErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			preparedTest := prepareTest(tt.dirName, "", tt.format)
-			connsRes, peersRes, err := preparedTest.analyzer.ConnlistFromDirPath(preparedTest.dirPath)
+			connsRes, peersRes, _, err := preparedTest.analyzer.ConnlistFromDirPath(preparedTest.dirPath)
 
 			require.Nil(t, err, tt.name)
 			// "unable to decode ... connlist_output.json"
@@ -516,7 +516,7 @@ func TestConnlistOutputFatalErrors(t *testing.T) {
 			// re-run the test with new analyzer (to clear the analyzer.errors array )
 			preparedTest = prepareTest(tt.dirName, "", tt.format)
 			infos, _ := fsscanner.GetResourceInfosFromDirPath([]string{preparedTest.dirPath}, true, false)
-			connsRes2, peersRes2, err2 := preparedTest.analyzer.ConnlistFromResourceInfos(infos)
+			connsRes2, peersRes2, _, err2 := preparedTest.analyzer.ConnlistFromResourceInfos(infos)
 
 			require.Nil(t, err2, tt.name)
 			require.Empty(t, preparedTest.analyzer.errors, "expecting no errors from ConnlistFromResourceInfos")

--- a/pkg/netpol/connlist/exposed_peer.go
+++ b/pkg/netpol/connlist/exposed_peer.go
@@ -15,6 +15,7 @@ type ExposedPeer interface {
 // XgressExposureData contains the data of potential connectivity for an existing peer in the cluster
 // a peer might be exposed to the entire cluster (any-namespace), to any namespace with labels or
 // any pod with labels in any-namespace, or any pod with labels in a namespace with labels, or any pod with labels in a specific namespace
+// TODO: add detailed documentation as to which combinations of values represent which kind of "abstract" node in the output
 type XgressExposureData interface {
 	// IsProtectedByNetpols indicates if the exposed peer is protected by any netpol on Ingress/Egress
 	// if a peer is not protected by xgress netpols, it will be exposed to entire cluster with all allowed connections

--- a/pkg/netpol/connlist/exposed_peer.go
+++ b/pkg/netpol/connlist/exposed_peer.go
@@ -12,7 +12,9 @@ type ExposedPeer interface {
 	EgressExposure() []XgressExposureData
 }
 
-// XgressExposureData contains data of potential connectivity for an existing peer to/from a representative peer
+// XgressExposureData contains the data of potential connectivity for an existing peer in the cluster
+// a peer might be exposed to the entire cluster (any-namespace), to any namespace with labels or
+// any pod with labels in any-namespace, or any pod with labels in a namespace with labels, or any pod with labels in a specific namespace
 type XgressExposureData interface {
 	// IsProtectedByNetpols indicates if the exposed peer is protected by any netpol on Ingress/Egress
 	// if a peer is not protected by xgress netpols, it will be exposed to entire cluster with all allowed connections

--- a/pkg/netpol/connlist/exposed_pods.go
+++ b/pkg/netpol/connlist/exposed_pods.go
@@ -1,0 +1,16 @@
+package connlist
+
+import "github.com/np-guard/netpol-analyzer/pkg/netpol/internal/common"
+
+// ExposedPeer captures potential ingress and egress connections data for an exposed Peer
+type ExposedPeer interface {
+	ExposedPeer() Peer // UnprotectedPeer()
+	IngressExposure() []XgressExposureData
+	EgressExposure() []XgressExposureData
+}
+
+// XgressExposureData data of potential connectivity for an existing peer to/from a representative peer
+type XgressExposureData interface {
+	RepresentativePeer() Peer
+	PotentialConnectivity() common.AllowedConnectivity
+}

--- a/pkg/netpol/connlist/exposed_pods.go
+++ b/pkg/netpol/connlist/exposed_pods.go
@@ -5,13 +5,23 @@ import "github.com/np-guard/netpol-analyzer/pkg/netpol/internal/common"
 // ExposedPeer captures potential ingress and egress connections data for an exposed Peer
 type ExposedPeer interface {
 	// ExposedPeer is a peer for which the analysis found some potential exposure info
-	ExposedPeer() Peer 
+	ExposedPeer() Peer
+	// IngressExposure list of the potential Ingress connections to the ExposedPeer
 	IngressExposure() []XgressExposureData
+	// EgressExposure list of the potential Egress connections from the ExposedPeer
 	EgressExposure() []XgressExposureData
 }
 
 // XgressExposureData data of potential connectivity for an existing peer to/from a representative peer
 type XgressExposureData interface {
-	RepresentativePeer() Peer
+	// IsProtectedByNetpols Is the exposed peer protected by any xgress netpol
+	IsProtectedByNetpols() bool
+	// IsExposedToEntireCluster is the peer exposed to all namespaces in the cluster for the relevant direction
+	IsExposedToEntireCluster() bool
+	// NamespaceLabels the potential namespaces which the peer is exposed to by their labels
+	NamespaceLabels() map[string]string
+	// PodLabels the potential pods which the peer might be exposed to by labels
+	PodLabels() map[string]string
+	// PotentialConnectivity the potential connectivity of the exposure
 	PotentialConnectivity() common.AllowedConnectivity
 }

--- a/pkg/netpol/connlist/exposed_pods.go
+++ b/pkg/netpol/connlist/exposed_pods.go
@@ -4,7 +4,8 @@ import "github.com/np-guard/netpol-analyzer/pkg/netpol/internal/common"
 
 // ExposedPeer captures potential ingress and egress connections data for an exposed Peer
 type ExposedPeer interface {
-	ExposedPeer() Peer // UnprotectedPeer()
+	// ExposedPeer is a peer for which the analysis found some potential exposure info
+	ExposedPeer() Peer 
 	IngressExposure() []XgressExposureData
 	EgressExposure() []XgressExposureData
 }

--- a/pkg/netpol/connlist/exposed_pods.go
+++ b/pkg/netpol/connlist/exposed_pods.go
@@ -6,21 +6,22 @@ import "github.com/np-guard/netpol-analyzer/pkg/netpol/internal/common"
 type ExposedPeer interface {
 	// ExposedPeer is a peer for which the analysis found some potential exposure info
 	ExposedPeer() Peer
-	// IngressExposure list of the potential Ingress connections to the ExposedPeer
+	// IngressExposure is a list of the potential Ingress connections to the ExposedPeer
 	IngressExposure() []XgressExposureData
-	// EgressExposure list of the potential Egress connections from the ExposedPeer
+	// EgressExposure is a list of the potential Egress connections from the ExposedPeer
 	EgressExposure() []XgressExposureData
 }
 
-// XgressExposureData data of potential connectivity for an existing peer to/from a representative peer
+// XgressExposureData contains data of potential connectivity for an existing peer to/from a representative peer
 type XgressExposureData interface {
-	// IsProtectedByNetpols indicates if the exposed peer is protected by any netpol on Ingress/Egress 
+	// IsProtectedByNetpols indicates if the exposed peer is protected by any netpol on Ingress/Egress
+	// if a peer is not protected by xgress netpols, it will be exposed to entire cluster with all allowed connections
 	IsProtectedByNetpols() bool
-	// IsExposedToEntireCluster is the peer exposed to all namespaces in the cluster for the relevant direction
+	// IsExposedToEntireCluster indicates if the peer is exposed to all namespaces in the cluster for the relevant direction
 	IsExposedToEntireCluster() bool
-	// NamespaceLabels the potential namespaces which the peer is exposed to by their labels
+	// NamespaceLabels are matchLabels of potential namespaces which the peer might be exposed to
 	NamespaceLabels() map[string]string
-	// PodLabels the potential pods which the peer might be exposed to by labels
+	// PodLabels are matchLabels of potential pods which the peer might be exposed to
 	PodLabels() map[string]string
 	// PotentialConnectivity the potential connectivity of the exposure
 	PotentialConnectivity() common.AllowedConnectivity

--- a/pkg/netpol/connlist/exposed_pods.go
+++ b/pkg/netpol/connlist/exposed_pods.go
@@ -14,7 +14,7 @@ type ExposedPeer interface {
 
 // XgressExposureData data of potential connectivity for an existing peer to/from a representative peer
 type XgressExposureData interface {
-	// IsProtectedByNetpols Is the exposed peer protected by any xgress netpol
+	// IsProtectedByNetpols indicates if the exposed peer is protected by any netpol on Ingress/Egress 
 	IsProtectedByNetpols() bool
 	// IsExposedToEntireCluster is the peer exposed to all namespaces in the cluster for the relevant direction
 	IsExposedToEntireCluster() bool

--- a/pkg/netpol/diff/connectivity_diff.go
+++ b/pkg/netpol/diff/connectivity_diff.go
@@ -1,8 +1,6 @@
 package diff
 
 import (
-	v1 "k8s.io/api/core/v1"
-
 	"github.com/np-guard/netpol-analyzer/pkg/netpol/eval"
 	"github.com/np-guard/netpol-analyzer/pkg/netpol/internal/common"
 )
@@ -33,9 +31,9 @@ type SrcDstDiff interface {
 	// Dst returns the destination peer
 	Dst() Peer
 	// Ref1Connectivity returns the AllowedConnectivity from src to dst in ref1
-	Ref1Connectivity() AllowedConnectivity
+	Ref1Connectivity() common.AllowedConnectivity
 	// Ref2Connectivity returns the AllowedConnectivity from src to dst in ref2
-	Ref2Connectivity() AllowedConnectivity
+	Ref2Connectivity() common.AllowedConnectivity
 	// IsSrcNewOrRemoved returns true if the src peer exists only in ref2 (if DiffType is Added) or if
 	// the src peer exists only in ref1 (if DiffType is Removed)
 	IsSrcNewOrRemoved() bool
@@ -47,13 +45,6 @@ type SrcDstDiff interface {
 }
 
 type Peer eval.Peer
-
-type AllowedConnectivity interface {
-	// AllProtocolsAndPorts returns true if all ports are allowed for all protocols
-	AllProtocolsAndPorts() bool
-	// ProtocolsAndPorts returns the set of allowed connections
-	ProtocolsAndPorts() map[v1.Protocol][]common.PortRange
-}
 
 type DiffTypeStr string
 

--- a/pkg/netpol/diff/diff.go
+++ b/pkg/netpol/diff/diff.go
@@ -145,7 +145,7 @@ func (da *DiffAnalyzer) getConnlistAnalysis(
 	error) {
 	// get a new ConnlistAnalyzer with muted errs/warns
 	connlistaAnalyzer := connlist.NewConnlistAnalyzer(da.determineConnlistAnalyzerOptions()...)
-	conns, workloads, err := connlistaAnalyzer.ConnlistFromResourceInfos(infos)
+	conns, workloads, _, err := connlistaAnalyzer.ConnlistFromResourceInfos(infos)
 
 	// append all fatal/severe errors and warnings returned by connlistaAnalyzer
 	errPrefix := da.errPrefixSpecifyRefName(isRef1)
@@ -414,7 +414,7 @@ func (c *connsPair) Dst() Peer {
 	return c.firstConn.Dst()
 }
 
-func (c *connsPair) Ref1Connectivity() AllowedConnectivity {
+func (c *connsPair) Ref1Connectivity() common.AllowedConnectivity {
 	if c.diffType == AddedType {
 		return &allowedConnectivity{
 			allProtocolsAndPorts: false,
@@ -427,7 +427,7 @@ func (c *connsPair) Ref1Connectivity() AllowedConnectivity {
 	}
 }
 
-func (c *connsPair) Ref2Connectivity() AllowedConnectivity {
+func (c *connsPair) Ref2Connectivity() common.AllowedConnectivity {
 	if c.diffType == RemovedType {
 		return &allowedConnectivity{
 			allProtocolsAndPorts: false,

--- a/pkg/netpol/internal/common/netpol_commands_common.go
+++ b/pkg/netpol/internal/common/netpol_commands_common.go
@@ -1,5 +1,9 @@
 package common
 
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
 // NetpolError holds information about a single error/warning that occurred during running
 // connectivity analysis command (list or diff)
 type NetpolError interface {
@@ -7,6 +11,13 @@ type NetpolError interface {
 	IsSevere() bool
 	Error() error
 	Location() string
+}
+
+type AllowedConnectivity interface {
+	// AllProtocolsAndPorts returns true if all ports are allowed for all protocols
+	AllProtocolsAndPorts() bool
+	// ProtocolsAndPorts returns the set of allowed connections
+	ProtocolsAndPorts() map[v1.Protocol][]PortRange
 }
 
 // Ingress Controller const - the name and namespace of an ingress-controller pod


### PR DESCRIPTION
this PR's goal is to define and implement the new API for `ConnlistFromResourceInfos` and `ConnlistFromDirPath` 

sub tasks :

- [x] define an interface for the new `exposure-analysis` results (new returned values from both funcs above)


this PR will resolve part of [this](https://github.com/np-guard/netpol-analyzer/pull/294#discussion_r1448389237)