### PR TITLE
Policy engine with new api func for exposure analysis 

### DIFF
--- a/pkg/netpol/connlist/connlist.go
+++ b/pkg/netpol/connlist/connlist.go
@@ -203,6 +203,7 @@ func (ca *ConnlistAnalyzer) getPolicyEngine(objectsList []parser.K8sObject) (*ev
 	if err != nil {
 		return nil, err
 	}
+	// TODO: this will be eliminated when adding representative peers while policies upsert
 	// add representative resources
 	err = pe.SetExposureAnalysisResources()
 	return pe, err

--- a/pkg/netpol/eval/check.go
+++ b/pkg/netpol/eval/check.go
@@ -274,21 +274,21 @@ func (pe *PolicyEngine) allallowedXgressConnections(src, dst k8s.Peer, isIngress
 		var policyAllowedConnectionsPerDirection *common.ConnectionSet
 		var err error
 		if isIngress {
-			// policy selecting dst
-			policyAllowedConnectionsPerDirection, err = policy.GetIngressAllowedConns(src, dst)
+			// policy selecting dst (dst pod is real)
 			if pe.exposureAnalysisFlag && !ingressSet[dst] {
 				// if this is first time scanning policies selecting this dst peer,
 				// update its ingress entire cluster connection relying on policy data
 				dst.GetPeerPod().UpdatePodXgressExposureToEntireClusterData(policy.IngressGeneralConns.EntireClusterConns, isIngress)
 			}
+			policyAllowedConnectionsPerDirection, err = policy.GetIngressAllowedConns(src, dst, pe.exposureAnalysisFlag)
 		} else {
 			// policy selecting src
-			policyAllowedConnectionsPerDirection, err = policy.GetEgressAllowedConns(dst)
 			if pe.exposureAnalysisFlag && !egressSet[src] {
 				// if this is first time scanning policies selecting this src peer,
 				// update its egress entire cluster connection relying on policy data
 				src.GetPeerPod().UpdatePodXgressExposureToEntireClusterData(policy.EgressGeneralConns.EntireClusterConns, isIngress)
 			}
+			policyAllowedConnectionsPerDirection, err = policy.GetEgressAllowedConns(dst, pe.exposureAnalysisFlag)
 		}
 		if err != nil {
 			return allowedConns, err

--- a/pkg/netpol/eval/check.go
+++ b/pkg/netpol/eval/check.go
@@ -280,7 +280,7 @@ func (pe *PolicyEngine) allallowedXgressConnections(src, dst k8s.Peer, isIngress
 				// update its ingress entire cluster connection relying on policy data
 				dst.GetPeerPod().UpdatePodXgressExposureToEntireClusterData(policy.IngressGeneralConns.EntireClusterConns, isIngress)
 			}
-			policyAllowedConnectionsPerDirection, err = policy.GetIngressAllowedConns(src, dst, pe.exposureAnalysisFlag)
+			policyAllowedConnectionsPerDirection, err = policy.GetIngressAllowedConns(src, dst)
 		} else {
 			// policy selecting src
 			if pe.exposureAnalysisFlag && !egressSet[src] {
@@ -288,7 +288,7 @@ func (pe *PolicyEngine) allallowedXgressConnections(src, dst k8s.Peer, isIngress
 				// update its egress entire cluster connection relying on policy data
 				src.GetPeerPod().UpdatePodXgressExposureToEntireClusterData(policy.EgressGeneralConns.EntireClusterConns, isIngress)
 			}
-			policyAllowedConnectionsPerDirection, err = policy.GetEgressAllowedConns(dst, pe.exposureAnalysisFlag)
+			policyAllowedConnectionsPerDirection, err = policy.GetEgressAllowedConns(dst)
 		}
 		if err != nil {
 			return allowedConns, err

--- a/pkg/netpol/eval/internal/k8s/netpol.go
+++ b/pkg/netpol/eval/internal/k8s/netpol.go
@@ -294,7 +294,7 @@ func (np *NetworkPolicy) EgressAllowedConn(dst Peer, protocol, port string) (boo
 	return false, nil
 }
 
-// GetEgressAllowedConns returns the set of allowed connetions from any captured pod to the destination peer
+// GetEgressAllowedConns returns the set of allowed connections from any captured pod to the destination peer
 // if exposureFlag is true; the result is initiated with the matching policy's general connections
 // and computations of rule conns are skipped for general rules;
 func (np *NetworkPolicy) GetEgressAllowedConns(dst Peer, exposureFlag bool) (*common.ConnectionSet, error) {

--- a/pkg/netpol/eval/internal/k8s/netpol.go
+++ b/pkg/netpol/eval/internal/k8s/netpol.go
@@ -37,7 +37,7 @@ import (
 // -> might help to preprocess and store peers that match policy selectors + selectors in rules + set of allowed connections per rule
 type NetworkPolicy struct {
 	*netv1.NetworkPolicy // embedding k8s network policy object
-	// following data stored in preprocessing;
+	// following data stored in preprocessing when exposure-analysis is on;
 	// IngressGeneralConns contains:
 	// - the maximal connection-set which the policy's rules allow to all destinations on ingress direction
 	// - the maximal connection-set which the policy's rules allow to all namespaces in the cluster on ingress direction
@@ -438,7 +438,7 @@ func (np *NetworkPolicy) fullName() string {
 }
 
 // /////////////////////////////////////////////////////////////////////////////////////////////
-// pre-processing computations - currently performed for exposure-analysis goals;
+// pre-processing computations - currently performed for exposure-analysis goals only;
 
 // DetermineGeneralConnectionsOfPolicy scans policy rules and updates if it allows conns with all destinations or/ and with entire cluster
 // for ingress and/ or egress directions

--- a/pkg/netpol/eval/internal/k8s/netpol.go
+++ b/pkg/netpol/eval/internal/k8s/netpol.go
@@ -48,6 +48,10 @@ type NetworkPolicy struct {
 	EgressGeneralConns PolicyGeneralRulesConns
 }
 
+// @todo might help if while pre-process, to check containment of all rules' connections; if all "specific" rules
+// connections are contained in the "general" rules connections, then we can avoid iterating policy rules for computing
+// connections between two peers
+
 type PolicyGeneralRulesConns struct {
 	// AllDestinationsConns contains the maximal connection-set which the policy's rules allow to all destinations
 	// (all namespaces, pods and IP addresses)

--- a/pkg/netpol/eval/resources.go
+++ b/pkg/netpol/eval/resources.go
@@ -69,6 +69,7 @@ func NewPolicyEngineWithOptions(exposureFlag bool) *PolicyEngine {
 	return pe
 }
 
+// AddObjects adds k8s objects from parsed resources to the policy engine
 func (pe *PolicyEngine) AddObjects(objects []parser.K8sObject) error {
 	var err error
 	for _, obj := range objects {

--- a/pkg/netpol/eval/resources.go
+++ b/pkg/netpol/eval/resources.go
@@ -56,6 +56,20 @@ func NewPolicyEngine() *PolicyEngine {
 
 func NewPolicyEngineWithObjects(objects []parser.K8sObject) (*PolicyEngine, error) {
 	pe := NewPolicyEngine()
+	err := pe.AddObjects(objects)
+	return pe, err
+}
+
+// NewPolicyEngineWithOptions returns a new policy engine with an empty state but updating the exposure analysis flag,
+// TBD: currently exposure-analysis is the only option supported by policy-engine, so no need for options param,
+// should have the exposureFlag or just assign to true in the func?
+func NewPolicyEngineWithOptions(exposureFlag bool) *PolicyEngine {
+	pe := NewPolicyEngine()
+	pe.exposureAnalysisFlag = exposureFlag
+	return pe
+}
+
+func (pe *PolicyEngine) AddObjects(objects []parser.K8sObject) error {
 	var err error
 	for _, obj := range objects {
 		switch obj.Kind {
@@ -85,17 +99,15 @@ func NewPolicyEngineWithObjects(objects []parser.K8sObject) (*PolicyEngine, erro
 			fmt.Printf("ignoring resource kind %s", obj.Kind)
 		}
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
-	err = pe.resolveMissingNamespaces()
-	return pe, err
+	return pe.resolveMissingNamespaces()
 }
 
 // SetExposureAnalysisResources sets the new representative peers needed for exposure analysis
-// TODO: changes may be done on optimizing PR (will the flag be relevant after optimize? , should have these both funcs?..)
+// TODO: changes may be done on optimizing PR (should have these both funcs?)
 func (pe *PolicyEngine) SetExposureAnalysisResources() error {
-	pe.exposureAnalysisFlag = true
 	// scan policies' rules for new pods in (unmatched) namespaces (TODO : and unmatched pods in un/matched namespaces)
 	return pe.addRepresentativePods()
 }
@@ -335,10 +347,12 @@ func (pe *PolicyEngine) upsertNetworkPolicy(np *netv1.NetworkPolicy) error {
 	}
 	pe.netpolsMap[netpolNamespace][np.Name] = newNetpol
 
-	// scan policy ingress and egress rules to store allowed connections
+	// for exposure analysis only: scan policy ingress and egress rules to store allowed connections
 	// to entire cluster and to all destinations (if such connections are allowed by the policy)
-	err := newNetpol.DetermineGeneralConnectionsOfPolicy()
-
+	var err error
+	if pe.exposureAnalysisFlag {
+		err = newNetpol.DetermineGeneralConnectionsOfPolicy()
+	}
 	// clear the cache on netpols changes
 	pe.cache.clear()
 	return err


### PR DESCRIPTION
issue #236


sub task : 

>   - [ ] adding new api func for policy-engine for running exposure-analysis individually([info](https://github.com/np-guard/netpol-analyzer/pull/306#issuecomment-1933431823))


PR's tasks :

- [x] adding new api func to the policy-engine; so all pre-process (and storing general conns for pods) will be computed only for exposure-analysis. (https://github.com/np-guard/netpol-analyzer/pull/307/commits/39172376d0e9867c2b42b16d8f41b8347872728b)

- [x] in case of exposure-analysis; updating some computation that can benefit from the stored data of the policy (https://github.com/np-guard/netpol-analyzer/pull/307/commits/a8474e2eeea1cb86c494be3c9892c9e7a183e352) and (https://github.com/np-guard/netpol-analyzer/pull/307/commits/e5a5270070c7bf3ad554df5be18bf8710744e253)


- tested locally with desired results