### PR TITLE
Optimize representative peers generation 

### DIFF
--- a/pkg/netpol/connlist/connlist.go
+++ b/pkg/netpol/connlist/connlist.go
@@ -196,16 +196,9 @@ func (ca *ConnlistAnalyzer) getPolicyEngine(objectsList []parser.K8sObject) (*ev
 	if !ca.exposureAnalysis {
 		return eval.NewPolicyEngineWithObjects(objectsList)
 	}
-	// else build new policy engine with exposure analysis
+	// else build new policy engine with exposure analysis option
 	pe := eval.NewPolicyEngineWithOptions(ca.exposureAnalysis)
-	// add objects from real resources
 	err := pe.AddObjects(objectsList)
-	if err != nil {
-		return nil, err
-	}
-	// TODO: this will be eliminated when adding representative peers while policies upsert
-	// add representative resources
-	err = pe.SetExposureAnalysisResources()
 	return pe, err
 }
 
@@ -225,16 +218,9 @@ func (ca *ConnlistAnalyzer) connslistFromParsedResources(objectsList []parser.K8
 
 // ConnlistFromK8sCluster returns the allowed connections list from k8s cluster resources, and list of all peers names
 func (ca *ConnlistAnalyzer) ConnlistFromK8sCluster(clientset *kubernetes.Clientset) ([]Peer2PeerConnection, []Peer, error) {
-	pe := eval.NewPolicyEngine()
-	if ca.exposureAnalysis {
-		err := pe.SetExposureAnalysisResources()
-		if err != nil {
-			return nil, nil, err
-		}
-	}
+	pe := eval.NewPolicyEngineWithOptions(ca.exposureAnalysis)
 
 	// get all resources from k8s cluster
-
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeoutSeconds*time.Second)
 	defer cancel()
 

--- a/pkg/netpol/eval/internal/k8s/namespace.go
+++ b/pkg/netpol/eval/internal/k8s/namespace.go
@@ -39,7 +39,8 @@ func NamespaceFromCoreObject(ns *corev1.Namespace) (*Namespace, error) {
 	for k, v := range ns.Labels {
 		n.Labels[k] = v
 	}
-
+	// @todo/tbd : should also add the name label as "name:<val>"  or assume policy rules
+	// selecting a namespace with name labels always use "kubernetes.io/metadata.name"
 	// if missing, the label set by k8s API server must be added to the namespace labels
 	if _, ok := n.Labels[K8sNsNameLabelKey]; !ok {
 		n.Labels[K8sNsNameLabelKey] = ns.Name

--- a/pkg/netpol/eval/internal/k8s/peer.go
+++ b/pkg/netpol/eval/internal/k8s/peer.go
@@ -72,6 +72,9 @@ type RepresentativePeer struct {
 	// and its namespace is a fake namespace with the namespaceSelector labels  (those labels also stored in PotentialNamespaceLabels)
 	Pod                      *Pod
 	PotentialNamespaceLabels map[string]string
+	// IsRedundant indicates if a real workload peer that fits labels of this peer and its namespace
+	// was found  while computing allowed connections between peers (so this peer should be refined)
+	IsRedundant bool
 }
 
 const podKind = "Pod"

--- a/pkg/netpol/eval/internal/k8s/peer.go
+++ b/pkg/netpol/eval/internal/k8s/peer.go
@@ -72,9 +72,6 @@ type RepresentativePeer struct {
 	// and its namespace is a fake namespace with the namespaceSelector labels  (those labels also stored in PotentialNamespaceLabels)
 	Pod                      *Pod
 	PotentialNamespaceLabels map[string]string
-	// IsRedundant indicates if a real workload peer that fits labels of this peer and its namespace
-	// was found  while computing allowed connections between peers (so this peer should be refined)
-	IsRedundant bool
 }
 
 const podKind = "Pod"

--- a/pkg/netpol/eval/internal/k8s/peer.go
+++ b/pkg/netpol/eval/internal/k8s/peer.go
@@ -114,11 +114,11 @@ func (p *WorkloadPeer) IsPeerIPType() bool {
 
 // //////////////////////////////////////////////////
 
-const RepresentativePodName = "representative-pod"
+const RepresentativePodName = "representative-pod" // todo: use as prefix of pod name when supporting podSelector
 const representativePodKind = "RepresentativePod"
 
 func (p *RepresentativePeer) Name() string {
-	return RepresentativePodName
+	return p.Pod.Name
 }
 
 func (p *RepresentativePeer) Namespace() string {

--- a/pkg/netpol/eval/internal/k8s/pod.go
+++ b/pkg/netpol/eval/internal/k8s/pod.go
@@ -112,7 +112,7 @@ func PodFromCoreObject(p *corev1.Pod) (*Pod, error) {
 		ownerRef := p.ObjectMeta.OwnerReferences[refIndex]
 		if *ownerRef.Controller {
 			if addOwner := addPodOwner(&ownerRef, pr); addOwner {
-				pr.Owner.Variant = variantFromLabelsMap(p.Labels)
+				pr.Owner.Variant = VariantFromLabelsMap(p.Labels)
 			}
 			break
 		}
@@ -226,7 +226,7 @@ func PodsFromWorkloadObject(workload interface{}, kind string) ([]*Pod, error) {
 		for i := range podTemplate.Spec.Containers {
 			pod.Ports = append(pod.Ports, podTemplate.Spec.Containers[i].Ports...)
 		}
-		pod.Owner.Variant = variantFromLabelsMap(podTemplate.Labels)
+		pod.Owner.Variant = VariantFromLabelsMap(podTemplate.Labels)
 		res[index-1] = pod
 	}
 	return res, nil
@@ -237,7 +237,8 @@ func namespacedName(pod *corev1.Pod) string {
 	return types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}.String()
 }
 
-func variantFromLabelsMap(labels map[string]string) string {
+// VariantFromLabelsMap returns a unique hash key from given labels map
+func VariantFromLabelsMap(labels map[string]string) string {
 	return hex.EncodeToString(sha1.New().Sum([]byte(fmt.Sprintf("%v", labels)))) //nolint:gosec // Non-crypto use
 }
 

--- a/pkg/netpol/eval/resources.go
+++ b/pkg/netpol/eval/resources.go
@@ -53,7 +53,6 @@ func NewPolicyEngine() *PolicyEngine {
 		podOwnersToRepresentativePodMap: make(map[string]map[string]*k8s.Pod),
 		cache:                           newEvalCache(),
 		exposureAnalysisFlag:            false,
-		representativePeersMap:          nil, // initialized only for exposure analysis
 	}
 }
 


### PR DESCRIPTION
#236 

sub-task :

> * - [ ]  optimize fake-pods generations 
        - first add `fake pods` for all non-empty rules while policies upsert
        - refine pods that has a match in the resources

in this PR:
1. created a representative peer for each rule with only non-empty `namespaceSelector` in the policies
2. refined while upserting pods and workloads (policies upserted first)

