### PR TITLE
Running golangci-lint action according to docs

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,8 +11,11 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
-          go-version: 1.19
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      - uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
+          go-version-file: ./go.mod
+          cache: false
+      - uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804
+        with:
+          version: latest

--- a/pkg/netpol/eval/internal/k8s/client.go
+++ b/pkg/netpol/eval/internal/k8s/client.go
@@ -75,7 +75,7 @@ func PodNamespace() (string, error) {
 		return ns, nil
 	}
 	if data, err := os.ReadFile(nsFile); err == nil {
-		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
+		if ns := strings.TrimSpace(string(data)); ns != "" {
 			return ns, nil
 		}
 		return "", err


### PR DESCRIPTION
According to the [Action docs](https://github.com/golangci/golangci-lint-action):
* The cache in `setup-go` should be disabled
* The version of golangci-lint to use must be specified