### PR TITLE
textual output with exposure analysis

### DIFF
--- a/pkg/cli/command_test.go
+++ b/pkg/cli/command_test.go
@@ -51,7 +51,7 @@ func buildAndExecuteCommand(args []string) (string, error) {
 }
 
 // append the optional args of a command if the values are not empty
-func addCmdOptionalArgs(format, outputFile, focusWorkload string) []string {
+func addCmdOptionalArgs(format, outputFile, focusWorkload string, exposure bool) []string {
 	res := []string{}
 	if focusWorkload != "" {
 		res = append(res, "--focusworkload", focusWorkload)
@@ -61,6 +61,9 @@ func addCmdOptionalArgs(format, outputFile, focusWorkload string) []string {
 	}
 	if outputFile != "" {
 		res = append(res, "-f", outputFile)
+	}
+	if exposure {
+		res = append(res, "--exposure")
 	}
 	return res
 }
@@ -75,9 +78,10 @@ func determineFileSuffix(format string) string {
 }
 
 // gets the test name and name of expected output file for a list command from its args
-func getListCmdTestNameAndExpectedOutputFile(dirName, focusWorkload, format string) (testName, expectedOutputFileName string) {
+func getListCmdTestNameAndExpectedOutputFile(dirName, focusWorkload, format string, exposureFlag bool) (testName,
+	expectedOutputFileName string) {
 	fileSuffix := determineFileSuffix(format)
-	return testutils.ConnlistTestNameByTestArgs(dirName, focusWorkload, fileSuffix)
+	return testutils.ConnlistTestNameByTestArgs(dirName, focusWorkload, fileSuffix, exposureFlag)
 }
 
 func testInfo(testName string) string {
@@ -211,6 +215,7 @@ func TestListCommandOutput(t *testing.T) {
 		focusWorkload string
 		format        string
 		outputFile    string
+		exposureFlag  bool
 	}{
 		// when focusWorkload is empty, output should be the connlist of the dir
 		// when format is empty - output should be in defaultFormat (txt)
@@ -259,13 +264,17 @@ func TestListCommandOutput(t *testing.T) {
 			dirName:    "onlineboutique",
 			outputFile: outFileName,
 		},
+		{
+			dirName:      "acs-security-demos",
+			exposureFlag: true,
+		},
 	}
 	for _, tt := range cases {
 		tt := tt
-		testName, expectedOutputFileName := getListCmdTestNameAndExpectedOutputFile(tt.dirName, tt.focusWorkload, tt.format)
+		testName, expectedOutputFileName := getListCmdTestNameAndExpectedOutputFile(tt.dirName, tt.focusWorkload, tt.format, tt.exposureFlag)
 		t.Run(testName, func(t *testing.T) {
 			args := []string{"list", "--dirpath", testutils.GetTestDirPath(tt.dirName)}
-			args = append(args, addCmdOptionalArgs(tt.format, tt.outputFile, tt.focusWorkload)...)
+			args = append(args, addCmdOptionalArgs(tt.format, tt.outputFile, tt.focusWorkload, tt.exposureFlag)...)
 			actualOut, err := buildAndExecuteCommand(args)
 			require.Nil(t, err, "test: %q", testName)
 			testutils.CheckActualVsExpectedOutputMatch(t, expectedOutputFileName, actualOut, testInfo(testName), currentPkg)
@@ -318,7 +327,7 @@ func TestDiffCommandOutput(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			args := []string{"diff", "--dir1", testutils.GetTestDirPath(tt.dir1), "--dir2",
 				testutils.GetTestDirPath(tt.dir2)}
-			args = append(args, addCmdOptionalArgs(tt.format, tt.outputFile, "")...)
+			args = append(args, addCmdOptionalArgs(tt.format, tt.outputFile, "", false)...)
 			actualOut, err := buildAndExecuteCommand(args)
 			require.Nil(t, err, "test: %q", testName)
 			testutils.CheckActualVsExpectedOutputMatch(t, expectedOutputFileName, actualOut, testInfo(testName), currentPkg)

--- a/pkg/cli/diff.go
+++ b/pkg/cli/diff.go
@@ -101,7 +101,7 @@ func newCommandDiff() *cobra.Command {
 	c.Flags().StringVarP(&dir1, dir1Arg, "", "", "Original Resources path to be compared")
 	c.Flags().StringVarP(&dir2, dir2Arg, "", "", "New Resources path to compare with original resources path")
 	supportedDiffFormats := strings.Join(diff.ValidDiffFormats, ",")
-	c.Flags().StringVarP(&outFormat, "output", "o", outconsts.DefaultFormat, getOutputFormatDescription(supportedDiffFormats))
+	c.Flags().StringVarP(&outFormat, "output", "o", outconsts.DefaultFormat, getRequiredOutputFormatString(supportedDiffFormats))
 	// out file
 	c.Flags().StringVarP(&outFile, "file", "f", "", "Write output to specified file")
 	return c

--- a/pkg/cli/list.go
+++ b/pkg/cli/list.go
@@ -33,8 +33,18 @@ var (
 	outFile          string // output file
 )
 
-func getOutputFormatDescription(validFormats string) string {
+// getRequiredOutputFormatString returns the description of required format(s) of the command
+func getRequiredOutputFormatString(validFormats string) string {
 	return fmt.Sprintf("Required output format (%s)", validFormats)
+}
+
+// getListOutputFormatDescription returns the description of the required formats of the list command
+// exposure analysis is supported with less formats
+func getListOutputFormatDescription() string {
+	comma := ","
+	supportedFormats := strings.Join(connlist.ValidFormats, comma)
+	supportedExposureFormats := strings.Join(connlist.ExposureValidFormats, comma)
+	return getRequiredOutputFormatString(supportedFormats) + " or (" + supportedExposureFormats + " with exposure analysis) "
 }
 
 func runListCommand() error {
@@ -108,7 +118,7 @@ defined`,
   k8snetpolicy list -k ./kube/config`,
 
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := connlist.ValidateOutputFormat(output); err != nil {
+			if err := connlist.ValidateOutputFormat(output, exposureAnalysis); err != nil {
 				return err
 			}
 			// call parent pre-run
@@ -137,8 +147,7 @@ defined`,
 		"Focus connections of specified workload in the output (<workload-name> or <workload-namespace/workload-name>)")
 	c.Flags().BoolVarP(&exposureAnalysis, "exposure", "", false, "Turn on exposure analysis and append results to the output")
 	// output format - default txt
-	supportedFormats := strings.Join(connlist.ValidFormats, ",")
-	c.Flags().StringVarP(&output, "output", "o", outconsts.DefaultFormat, getOutputFormatDescription(supportedFormats))
+	c.Flags().StringVarP(&output, "output", "o", outconsts.DefaultFormat, getListOutputFormatDescription())
 	// out file
 	c.Flags().StringVarP(&outFile, "file", "f", "", "Write output to specified file")
 

--- a/pkg/internal/testutils/testutils.go
+++ b/pkg/internal/testutils/testutils.go
@@ -35,8 +35,12 @@ func GetTestDirPath(dirName string) string {
 }
 
 // ConnlistTestNameByTestArgs returns connlist test name and test's expected output file from some tests args
-func ConnlistTestNameByTestArgs(dirName, focusWorkload, format string) (testName, expectedOutputFileName string) {
+func ConnlistTestNameByTestArgs(dirName, focusWorkload, format string, exposureFlag bool) (testName, expectedOutputFileName string) {
 	namePrefix := dirName
+	if exposureFlag {
+		// if dir name contains a separator; last element is enough for the test and file names
+		namePrefix = "exposure_" + filepath.Base(dirName)
+	}
 	if focusWorkload != "" {
 		namePrefix += focusWlAnnotation + strings.Replace(focusWorkload, "/", underscore, 1)
 	}

--- a/pkg/netpol/connlist/conns_formatter_csv.go
+++ b/pkg/netpol/connlist/conns_formatter_csv.go
@@ -10,7 +10,8 @@ type formatCSV struct {
 }
 
 // returns a CSV string form of connections from list of Peer2PeerConnection objects
-func (cs formatCSV) writeOutput(conns []Peer2PeerConnection) (string, error) {
+// this format is not supported with exposure analysis; exposureConns is not used;
+func (cs *formatCSV) writeOutput(conns []Peer2PeerConnection, exposureConns []ExposedPeer) (string, error) {
 	// get an array of sorted conns items ([]singleConnFields)
 	sortedConnItems := sortConnections(conns)
 	var headerCSV = []string{"src", "dst", "conn"}

--- a/pkg/netpol/connlist/conns_formatter_dot.go
+++ b/pkg/netpol/connlist/conns_formatter_dot.go
@@ -41,7 +41,8 @@ func getPeerLine(peer Peer) (string, bool) {
 }
 
 // returns a dot string form of connections from list of Peer2PeerConnection objects
-func (d formatDOT) writeOutput(conns []Peer2PeerConnection) (string, error) {
+// this format is not supported with exposure analysis; exposureConns is not used;
+func (d *formatDOT) writeOutput(conns []Peer2PeerConnection, exposureConns []ExposedPeer) (string, error) {
 	nsPeers := make(map[string][]string)     // map from namespace to its peers (grouping peers by namespaces)
 	externalPeersLines := make([]string, 0)  // list of peers which are not in a cluster's namespace (will not be grouped)
 	edgeLines := make([]string, len(conns))  // list of edges lines

--- a/pkg/netpol/connlist/conns_formatter_json.go
+++ b/pkg/netpol/connlist/conns_formatter_json.go
@@ -7,7 +7,8 @@ type formatJSON struct {
 }
 
 // returns a json string form of connections from list of Peer2PeerConnection objects
-func (j formatJSON) writeOutput(conns []Peer2PeerConnection) (string, error) {
+// this format is not supported with exposure analysis; exposureConns is not used;
+func (j *formatJSON) writeOutput(conns []Peer2PeerConnection, exposureConns []ExposedPeer) (string, error) {
 	// get an array of sorted conns items ([]singleConnFields)
 	sortedConnItems := sortConnections(conns)
 	jsonConns, err := json.MarshalIndent(sortedConnItems, "", "  ")

--- a/pkg/netpol/connlist/conns_formatter_md.go
+++ b/pkg/netpol/connlist/conns_formatter_md.go
@@ -21,10 +21,11 @@ func getMDLine(c singleConnFields) string {
 }
 
 // returns a md string form of connections from list of Peer2PeerConnection objects
-func (md formatMD) writeOutput(conns []Peer2PeerConnection) (string, error) {
+// this format is not supported with exposure analysis; exposureConns is not used;
+func (md *formatMD) writeOutput(conns []Peer2PeerConnection, exposureConns []ExposedPeer) (string, error) {
 	mdLines := make([]string, len(conns))
 	for index := range conns {
-		mdLines[index] = getMDLine(formSingleConn(conns[index]))
+		mdLines[index] = getMDLine(formSingleP2PConn(conns[index]))
 	}
 	sort.Strings(mdLines)
 	allLines := []string{getMDHeader()}

--- a/pkg/netpol/connlist/conns_formatter_txt.go
+++ b/pkg/netpol/connlist/conns_formatter_txt.go
@@ -3,18 +3,135 @@ package connlist
 import (
 	"sort"
 	"strings"
+
+	"github.com/np-guard/netpol-analyzer/pkg/netpol/internal/common"
 )
 
 // formatText: implements the connsFormatter interface for txt output format
 type formatText struct {
+	// PeerToConnsFromIPs map from real peer.String() to its ingress connections from ip-blocks lines
+	// extracted from the []Peer2PeerConnection conns to be appended also to the exposure-analysis output
+	PeerToConnsFromIPs map[string][]string
+	// peerToConnsToIPs map from real peer.String() to its egress connections to ip-blocks lines
+	// extracted from the []Peer2PeerConnection conns to be appended also to the exposure-analysis output
+	peerToConnsToIPs map[string][]string
 }
 
-// returns a textual string format of connections from list of Peer2PeerConnection objects
-func (t formatText) writeOutput(conns []Peer2PeerConnection) (string, error) {
+// writeOutput returns a textual string format of connections from list of Peer2PeerConnection objects,
+// and exposure analysis results if exist
+func (t *formatText) writeOutput(conns []Peer2PeerConnection, exposureConns []ExposedPeer) (string, error) {
+	exposureFlag := len(exposureConns) > 0
+	res := t.writeConnlistOutput(conns, exposureFlag)
+	if !exposureFlag {
+		return res, nil
+	}
+	// else append exposure analysis results:
+	if res != "" {
+		res += "\n\n"
+	}
+	res += t.writeExposureOutput(exposureConns)
+	return res, nil
+}
+
+func (t *formatText) writeConnlistOutput(conns []Peer2PeerConnection, saveIPConns bool) string {
 	connLines := make([]string, len(conns))
-	for i := range conns {
-		connLines[i] = formSingleConn(conns[i]).string()
+	if saveIPConns {
+		t.peerToConnsToIPs = make(map[string][]string)
+		t.PeerToConnsFromIPs = make(map[string][]string)
+	}
+	for i, conn := range conns {
+		connLines[i] = formSingleP2PConn(conns[i]).string()
+		// if we have exposure analysis results, also check if src/dst is an IP and store the connection
+		if saveIPConns {
+			if conn.Src().IsPeerIPType() {
+				t.PeerToConnsFromIPs[conn.Dst().String()] = append(t.PeerToConnsFromIPs[conn.Dst().String()], connLines[i])
+			}
+			if conn.Dst().IsPeerIPType() {
+				t.peerToConnsToIPs[conn.Src().String()] = append(t.peerToConnsToIPs[conn.Src().String()], connLines[i])
+			}
+		}
 	}
 	sort.Strings(connLines)
-	return strings.Join(connLines, newLineChar), nil
+	return strings.Join(connLines, newLineChar)
+}
+
+func (t *formatText) writeExposureOutput(exposureResults []ExposedPeer) string {
+	// sorting the exposed peers slice so we get unique sorted output by Peer.String()
+	sortedExposureResults := sortExposedPeerSlice(exposureResults)
+	exposureLines := make([]string, 0)
+	unprotectedLines := make([]string, 0)
+	for _, ep := range sortedExposureResults {
+		// ingress and egress lines per peer, internally sorted
+		ingressLines, ingressUnprotectedLine := t.getPeerIngressExposureLines(ep)
+		exposureLines = append(exposureLines, ingressLines...)
+		if ingressUnprotectedLine != "" {
+			unprotectedLines = append(unprotectedLines, ingressUnprotectedLine)
+		}
+		egressLines, egressUnprotectedLine := t.getPeerEgressExposureLines(ep)
+		exposureLines = append(exposureLines, egressLines...)
+		if egressUnprotectedLine != "" {
+			unprotectedLines = append(unprotectedLines, egressUnprotectedLine)
+		}
+	}
+	res := "Exposure Analysis Result:\n"
+	res += strings.Join(exposureLines, newLineChar)
+	if len(unprotectedLines) > 0 {
+		res += "\n\nWorkloads which are not protected by network policies:\n"
+		sort.Strings(unprotectedLines)
+		res += strings.Join(unprotectedLines, newLineChar)
+	}
+	return res
+}
+
+func (t *formatText) getPeerIngressExposureLines(ep ExposedPeer) (ingressLines []string, ingressUnprotectedLine string) {
+	// if a peer is not protected, two lines are to be added to exposure analysis result:
+	// 1. all conns with entire cluster (added here)
+	// 2. all conns with ip-blocks (all destinations); for sure found in the ip conns map so will be added automatically
+	// also unprotected line will be added
+	if !ep.IsProtectedByIngressNetpols() {
+		ingressLines = append(ingressLines, formSingleExposureConn(entireCluster, ep.ExposedPeer().String(),
+			common.MakeConnectionSet(true)).string())
+		ingressUnprotectedLine = ep.ExposedPeer().String() + " is not protected on Ingress"
+	} else { // protected
+		for _, data := range ep.IngressExposure() {
+			// for txt output append the string of the singleConnFields
+			ingressLines = append(ingressLines, formExposureItemAsSingleConnFiled(ep.ExposedPeer(), data, true).string())
+		}
+	}
+	// append ingress ip conns to this peer
+	if ipConns, ok := t.PeerToConnsFromIPs[ep.ExposedPeer().String()]; ok {
+		ingressLines = append(ingressLines, ipConns...)
+	}
+	sort.Strings(ingressLines)
+	return ingressLines, ingressUnprotectedLine
+}
+
+func (t *formatText) getPeerEgressExposureLines(ep ExposedPeer) (egressLines []string, egressUnprotectedLine string) {
+	// if a peer is not protected, two lines are to be added to exposure analysis result:
+	// 1. all conns with entire cluster (added here)
+	// 2. all conns with ip-blocks (all destinations); for sure found in the ip conns map so will be added automatically
+	// also unprotected line will be added
+	if !ep.IsProtectedByEgressNetpols() {
+		egressLines = append(egressLines, formSingleExposureConn(ep.ExposedPeer().String(), entireCluster,
+			common.MakeConnectionSet(true)).string())
+		egressUnprotectedLine = ep.ExposedPeer().String() + " is not protected on Egress"
+	} else { // protected
+		for _, data := range ep.EgressExposure() {
+			// for txt output append the string of the singleConnFields
+			egressLines = append(egressLines, formExposureItemAsSingleConnFiled(ep.ExposedPeer(), data, false).string())
+		}
+	}
+	// append egress ip conns to this peer
+	if ipConns, ok := t.peerToConnsToIPs[ep.ExposedPeer().String()]; ok {
+		egressLines = append(egressLines, ipConns...)
+	}
+	sort.Strings(egressLines)
+	return egressLines, egressUnprotectedLine
+}
+
+func sortExposedPeerSlice(exposedPeers []ExposedPeer) []ExposedPeer {
+	sort.Slice(exposedPeers, func(i, j int) bool {
+		return exposedPeers[i].ExposedPeer().String() < exposedPeers[j].ExposedPeer().String()
+	})
+	return exposedPeers
 }

--- a/test_outputs/cli/exposure_acs-security-demos_connlist_output.txt
+++ b/test_outputs/cli/exposure_acs-security-demos_connlist_output.txt
@@ -1,0 +1,23 @@
+backend/checkout[Deployment] => backend/notification[Deployment] : TCP 8080
+backend/checkout[Deployment] => backend/recommendation[Deployment] : TCP 8080
+backend/checkout[Deployment] => payments/gateway[Deployment] : TCP 8080
+backend/recommendation[Deployment] => backend/catalog[Deployment] : TCP 8080
+backend/reports[Deployment] => backend/catalog[Deployment] : TCP 8080
+backend/reports[Deployment] => backend/recommendation[Deployment] : TCP 8080
+frontend/webapp[Deployment] => backend/checkout[Deployment] : TCP 8080
+frontend/webapp[Deployment] => backend/recommendation[Deployment] : TCP 8080
+frontend/webapp[Deployment] => backend/reports[Deployment] : TCP 8080
+frontend/webapp[Deployment] => backend/shipping[Deployment] : TCP 8080
+payments/gateway[Deployment] => payments/mastercard-processor[Deployment] : TCP 8080
+payments/gateway[Deployment] => payments/visa-processor[Deployment] : TCP 8080
+{ingress-controller} => frontend/asset-cache[Deployment] : TCP 8080
+{ingress-controller} => frontend/webapp[Deployment] : TCP 8080
+
+Exposure Analysis Result:
+backend/checkout[Deployment] => entire-cluster : UDP 5353
+backend/recommendation[Deployment] => entire-cluster : UDP 5353
+backend/reports[Deployment] => entire-cluster : UDP 5353
+entire-cluster => frontend/asset-cache[Deployment] : TCP 8080
+entire-cluster => frontend/webapp[Deployment] : TCP 8080
+frontend/webapp[Deployment] => entire-cluster : UDP 5353
+payments/gateway[Deployment] => entire-cluster : UDP 5353

--- a/test_outputs/connlist/exposure_acs-security-demos_connlist_output.txt
+++ b/test_outputs/connlist/exposure_acs-security-demos_connlist_output.txt
@@ -1,0 +1,23 @@
+backend/checkout[Deployment] => backend/notification[Deployment] : TCP 8080
+backend/checkout[Deployment] => backend/recommendation[Deployment] : TCP 8080
+backend/checkout[Deployment] => payments/gateway[Deployment] : TCP 8080
+backend/recommendation[Deployment] => backend/catalog[Deployment] : TCP 8080
+backend/reports[Deployment] => backend/catalog[Deployment] : TCP 8080
+backend/reports[Deployment] => backend/recommendation[Deployment] : TCP 8080
+frontend/webapp[Deployment] => backend/checkout[Deployment] : TCP 8080
+frontend/webapp[Deployment] => backend/recommendation[Deployment] : TCP 8080
+frontend/webapp[Deployment] => backend/reports[Deployment] : TCP 8080
+frontend/webapp[Deployment] => backend/shipping[Deployment] : TCP 8080
+payments/gateway[Deployment] => payments/mastercard-processor[Deployment] : TCP 8080
+payments/gateway[Deployment] => payments/visa-processor[Deployment] : TCP 8080
+{ingress-controller} => frontend/asset-cache[Deployment] : TCP 8080
+{ingress-controller} => frontend/webapp[Deployment] : TCP 8080
+
+Exposure Analysis Result:
+backend/checkout[Deployment] => entire-cluster : UDP 5353
+backend/recommendation[Deployment] => entire-cluster : UDP 5353
+backend/reports[Deployment] => entire-cluster : UDP 5353
+entire-cluster => frontend/asset-cache[Deployment] : TCP 8080
+entire-cluster => frontend/webapp[Deployment] : TCP 8080
+frontend/webapp[Deployment] => entire-cluster : UDP 5353
+payments/gateway[Deployment] => entire-cluster : UDP 5353

--- a/test_outputs/connlist/exposure_test_allow_all_connlist_output.txt
+++ b/test_outputs/connlist/exposure_test_allow_all_connlist_output.txt
@@ -1,0 +1,8 @@
+0.0.0.0-255.255.255.255 => hello-world/workload-a[Deployment] : All Connections
+hello-world/workload-a[Deployment] => 0.0.0.0-255.255.255.255 : All Connections
+
+Exposure Analysis Result:
+0.0.0.0-255.255.255.255 => hello-world/workload-a[Deployment] : All Connections
+entire-cluster => hello-world/workload-a[Deployment] : All Connections
+hello-world/workload-a[Deployment] => 0.0.0.0-255.255.255.255 : All Connections
+hello-world/workload-a[Deployment] => entire-cluster : All Connections

--- a/test_outputs/connlist/exposure_test_allow_all_in_cluster_connlist_output.txt
+++ b/test_outputs/connlist/exposure_test_allow_all_in_cluster_connlist_output.txt
@@ -1,0 +1,3 @@
+Exposure Analysis Result:
+entire-cluster => hello-world/workload-a[Deployment] : TCP 8050
+hello-world/workload-a[Deployment] => entire-cluster : All Connections

--- a/test_outputs/connlist/exposure_test_allow_egress_deny_ingress_connlist_output.txt
+++ b/test_outputs/connlist/exposure_test_allow_egress_deny_ingress_connlist_output.txt
@@ -1,0 +1,5 @@
+hello-world/workload-a[Deployment] => 0.0.0.0-255.255.255.255 : All Connections
+
+Exposure Analysis Result:
+hello-world/workload-a[Deployment] => 0.0.0.0-255.255.255.255 : All Connections
+hello-world/workload-a[Deployment] => entire-cluster : All Connections

--- a/test_outputs/connlist/exposure_test_allow_ingress_deny_egress_connlist_output.txt
+++ b/test_outputs/connlist/exposure_test_allow_ingress_deny_egress_connlist_output.txt
@@ -1,0 +1,5 @@
+0.0.0.0-255.255.255.255 => hello-world/workload-a[Deployment] : All Connections
+
+Exposure Analysis Result:
+0.0.0.0-255.255.255.255 => hello-world/workload-a[Deployment] : All Connections
+entire-cluster => hello-world/workload-a[Deployment] : All Connections

--- a/test_outputs/connlist/exposure_test_egress_exposure_with_named_port_connlist_output.txt
+++ b/test_outputs/connlist/exposure_test_egress_exposure_with_named_port_connlist_output.txt
@@ -1,0 +1,3 @@
+Exposure Analysis Result:
+entire-cluster => hello-world/workload-a[Deployment] : TCP 8000
+hello-world/workload-a[Deployment] => any namespace with foo.com/managed-state=managed : TCP http

--- a/test_outputs/connlist/exposure_test_egress_to_entire_cluster_with_named_ports_connlist_output.txt
+++ b/test_outputs/connlist/exposure_test_egress_to_entire_cluster_with_named_ports_connlist_output.txt
@@ -1,0 +1,9 @@
+0.0.0.0-255.255.255.255 => hello-world/workload-a[Deployment] : All Connections
+
+Exposure Analysis Result:
+0.0.0.0-255.255.255.255 => hello-world/workload-a[Deployment] : All Connections
+entire-cluster => hello-world/workload-a[Deployment] : All Connections
+hello-world/workload-a[Deployment] => entire-cluster : TCP http,local-dns
+
+Workloads which are not protected by network policies:
+hello-world/workload-a[Deployment] is not protected on Ingress

--- a/test_outputs/connlist/exposure_test_ingress_from_entire_cluster_with_named_ports_connlist_output.txt
+++ b/test_outputs/connlist/exposure_test_ingress_from_entire_cluster_with_named_ports_connlist_output.txt
@@ -1,0 +1,9 @@
+hello-world/workload-a[Deployment] => 0.0.0.0-255.255.255.255 : All Connections
+
+Exposure Analysis Result:
+entire-cluster => hello-world/workload-a[Deployment] : TCP 8000,8090
+hello-world/workload-a[Deployment] => 0.0.0.0-255.255.255.255 : All Connections
+hello-world/workload-a[Deployment] => entire-cluster : All Connections
+
+Workloads which are not protected by network policies:
+hello-world/workload-a[Deployment] is not protected on Egress

--- a/test_outputs/connlist/exposure_test_matched_and_unmatched_rules_connlist_output.txt
+++ b/test_outputs/connlist/exposure_test_matched_and_unmatched_rules_connlist_output.txt
@@ -1,0 +1,19 @@
+0.0.0.0-255.255.255.255 => hello-world/workload-b[Deployment] : All Connections
+hello-world/workload-a[Deployment] => 0.0.0.0-255.255.255.255 : All Connections
+hello-world/workload-a[Deployment] => hello-world/workload-b[Deployment] : All Connections
+hello-world/workload-b[Deployment] => 0.0.0.0-255.255.255.255 : All Connections
+hello-world/workload-b[Deployment] => hello-world/workload-a[Deployment] : All Connections
+
+Exposure Analysis Result:
+entire-cluster => hello-world/workload-a[Deployment] : TCP 8050
+hello-world/workload-a[Deployment] => 0.0.0.0-255.255.255.255 : All Connections
+hello-world/workload-a[Deployment] => entire-cluster : All Connections
+0.0.0.0-255.255.255.255 => hello-world/workload-b[Deployment] : All Connections
+entire-cluster => hello-world/workload-b[Deployment] : All Connections
+hello-world/workload-b[Deployment] => 0.0.0.0-255.255.255.255 : All Connections
+hello-world/workload-b[Deployment] => entire-cluster : All Connections
+
+Workloads which are not protected by network policies:
+hello-world/workload-a[Deployment] is not protected on Egress
+hello-world/workload-b[Deployment] is not protected on Egress
+hello-world/workload-b[Deployment] is not protected on Ingress

--- a/test_outputs/connlist/exposure_test_multiple_unmatched_rules_connlist_output.txt
+++ b/test_outputs/connlist/exposure_test_multiple_unmatched_rules_connlist_output.txt
@@ -1,0 +1,11 @@
+hello-world/workload-a[Deployment] => 0.0.0.0-255.255.255.255 : All Connections
+
+Exposure Analysis Result:
+any namespace with effect=NoSchedule => hello-world/workload-a[Deployment] : TCP 8050
+any namespace with foo.com/managed-state=managed => hello-world/workload-a[Deployment] : TCP 8050
+any namespace with release=stable => hello-world/workload-a[Deployment] : All Connections
+hello-world/workload-a[Deployment] => 0.0.0.0-255.255.255.255 : All Connections
+hello-world/workload-a[Deployment] => entire-cluster : All Connections
+
+Workloads which are not protected by network policies:
+hello-world/workload-a[Deployment] is not protected on Egress

--- a/test_outputs/connlist/exposure_test_new_namespace_conn_and_entire_cluster_connlist_output.txt
+++ b/test_outputs/connlist/exposure_test_new_namespace_conn_and_entire_cluster_connlist_output.txt
@@ -1,0 +1,20 @@
+0.0.0.0-255.255.255.255 => hello-world/workload-b[Deployment] : All Connections
+hello-world/workload-a[Deployment] => 0.0.0.0-255.255.255.255 : All Connections
+hello-world/workload-a[Deployment] => hello-world/workload-b[Deployment] : All Connections
+hello-world/workload-b[Deployment] => 0.0.0.0-255.255.255.255 : All Connections
+hello-world/workload-b[Deployment] => hello-world/workload-a[Deployment] : All Connections
+
+Exposure Analysis Result:
+any namespace with foo.com/managed-state=managed => hello-world/workload-a[Deployment] : TCP 8050,8090
+entire-cluster => hello-world/workload-a[Deployment] : TCP 8050
+hello-world/workload-a[Deployment] => 0.0.0.0-255.255.255.255 : All Connections
+hello-world/workload-a[Deployment] => entire-cluster : All Connections
+0.0.0.0-255.255.255.255 => hello-world/workload-b[Deployment] : All Connections
+entire-cluster => hello-world/workload-b[Deployment] : All Connections
+hello-world/workload-b[Deployment] => 0.0.0.0-255.255.255.255 : All Connections
+hello-world/workload-b[Deployment] => entire-cluster : All Connections
+
+Workloads which are not protected by network policies:
+hello-world/workload-a[Deployment] is not protected on Egress
+hello-world/workload-b[Deployment] is not protected on Egress
+hello-world/workload-b[Deployment] is not protected on Ingress

--- a/test_outputs/connlist/exposure_test_only_matched_rules_connlist_output.txt
+++ b/test_outputs/connlist/exposure_test_only_matched_rules_connlist_output.txt
@@ -1,0 +1,14 @@
+0.0.0.0-255.255.255.255 => hello-world/workload-b[Deployment] : All Connections
+hello-world/workload-a[Deployment] => hello-world/workload-b[Deployment] : All Connections
+hello-world/workload-b[Deployment] => 0.0.0.0-255.255.255.255 : All Connections
+hello-world/workload-b[Deployment] => hello-world/workload-a[Deployment] : All Connections
+
+Exposure Analysis Result:
+0.0.0.0-255.255.255.255 => hello-world/workload-b[Deployment] : All Connections
+entire-cluster => hello-world/workload-b[Deployment] : All Connections
+hello-world/workload-b[Deployment] => 0.0.0.0-255.255.255.255 : All Connections
+hello-world/workload-b[Deployment] => entire-cluster : All Connections
+
+Workloads which are not protected by network policies:
+hello-world/workload-b[Deployment] is not protected on Egress
+hello-world/workload-b[Deployment] is not protected on Ingress

--- a/test_outputs/connlist/exposure_test_same_unmatched_rule_in_ingress_egress_connlist_output.txt
+++ b/test_outputs/connlist/exposure_test_same_unmatched_rule_in_ingress_egress_connlist_output.txt
@@ -1,0 +1,4 @@
+Exposure Analysis Result:
+any namespace with foo.com/managed-state=managed => hello-world/workload-a[Deployment] : TCP 8000,8090
+entire-cluster => hello-world/workload-a[Deployment] : TCP 8000
+hello-world/workload-a[Deployment] => any namespace with foo.com/managed-state=managed : TCP 8050

--- a/test_outputs/connlist/exposure_test_with_no_netpols_connlist_output.txt
+++ b/test_outputs/connlist/exposure_test_with_no_netpols_connlist_output.txt
@@ -1,0 +1,12 @@
+0.0.0.0-255.255.255.255 => hello-world/workload-a[Deployment] : All Connections
+hello-world/workload-a[Deployment] => 0.0.0.0-255.255.255.255 : All Connections
+
+Exposure Analysis Result:
+0.0.0.0-255.255.255.255 => hello-world/workload-a[Deployment] : All Connections
+entire-cluster => hello-world/workload-a[Deployment] : All Connections
+hello-world/workload-a[Deployment] => 0.0.0.0-255.255.255.255 : All Connections
+hello-world/workload-a[Deployment] => entire-cluster : All Connections
+
+Workloads which are not protected by network policies:
+hello-world/workload-a[Deployment] is not protected on Egress
+hello-world/workload-a[Deployment] is not protected on Ingress

--- a/tests/test_egress_exposure_with_named_port/namespace_and_deployments.yaml
+++ b/tests/test_egress_exposure_with_named_port/namespace_and_deployments.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hello-world
+spec: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workload-a
+  namespace: hello-world
+  labels:
+    app: a-app
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: a-app
+  template:
+    metadata:
+      labels:
+        app: a-app
+    spec:
+      containers:
+      - name: hello-world
+        image: quay.io/shfa/hello-world:latest
+        ports:
+        - name: local-dns
+          containerPort: 8000  # containerport1
+        - name: local-dns2
+          containerPort: 8050  # containerport2
+        - name: http
+          containerPort: 8090  # containerport3
+---

--- a/tests/test_egress_exposure_with_named_port/netpol.yaml
+++ b/tests/test_egress_exposure_with_named_port/netpol.yaml
@@ -1,0 +1,26 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: egress-with-named-port
+  namespace: hello-world
+spec:
+  podSelector:
+    matchLabels:
+      app: a-app
+  ingress:
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - port: local-dns
+      protocol: TCP
+  egress:
+  - to:
+    - namespaceSelector:
+           matchExpressions:
+           - key: foo.com/managed-state
+             operator: In
+             values:
+             - managed
+    ports:
+    - port: http
+      protocol: TCP

--- a/tests/test_egress_to_entire_cluster_with_named_ports/namespace_and_deployments.yaml
+++ b/tests/test_egress_to_entire_cluster_with_named_ports/namespace_and_deployments.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hello-world
+spec: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workload-a
+  namespace: hello-world
+  labels:
+    app: a-app
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: a-app
+  template:
+    metadata:
+      labels:
+        app: a-app
+    spec:
+      containers:
+      - name: hello-world
+        image: quay.io/shfa/hello-world:latest
+        ports:
+        - name: local-dns
+          containerPort: 8000  # containerport1
+        - name: local-dns2
+          containerPort: 8050  # containerport2
+        - name: http
+          containerPort: 8090  # containerport3
+---

--- a/tests/test_egress_to_entire_cluster_with_named_ports/policy.yaml
+++ b/tests/test_egress_to_entire_cluster_with_named_ports/policy.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-based-on-named-ports
+  namespace: hello-world
+spec:
+  podSelector: 
+    matchLabels:
+      app: a-app
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector: {}
+    ports:
+        - port: local-dns
+        - port: http

--- a/tests/test_ingress_from_entire_cluster_with_named_ports/namespace_and_deployments.yaml
+++ b/tests/test_ingress_from_entire_cluster_with_named_ports/namespace_and_deployments.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hello-world
+spec: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workload-a
+  namespace: hello-world
+  labels:
+    app: a-app
+spec:
+  selector:
+    matchLabels:
+      app: a-app
+  template:
+    metadata:
+      labels:
+        app: a-app
+    spec:
+      containers:
+      - name: hello-world
+        image: quay.io/shfa/hello-world:latest
+        ports:
+        - name: local-dns
+          containerPort: 8000  # containerport1
+        - name: local-dns2
+          containerPort: 8050  # containerport2
+        - name: http
+          containerPort: 8090  # containerport3
+---

--- a/tests/test_ingress_from_entire_cluster_with_named_ports/policy.yaml
+++ b/tests/test_ingress_from_entire_cluster_with_named_ports/policy.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ingress-based-on-named-ports
+  namespace: hello-world
+spec:
+  podSelector: 
+    matchLabels:
+      app: a-app
+  policyTypes:
+  - Ingress
+  ingress: 
+    - from:
+      - namespaceSelector: {}
+      ports:
+        - port: local-dns
+        - port: http


### PR DESCRIPTION
issue #236

task:

> - [ ] adding exposure analysis results in textual output


this PR:
- adding exposure-analysis results to the connlist textual output
- adding tests to both `command_test.go` and `connlist_test.go` (running with the new `exposure` flag)
- running the `list` command  with `--exposure` is enabled only with `txt` format (will get an error trying to run with another formats); 
- the expected output :
     - currently is in the same form of the `connlist` output (=> one direction) (w.i.p trying other versions)
     - lines are sorted by real Peer.String() , i.e. all exposure results of a single peer are written successively 