### PR TITLE
Revert "Bump github.com/np-guard/models from 0.3.4 to 0.5.0 (#417)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,10 @@
 module github.com/np-guard/netpol-analyzer
 
-go 1.23
-
-toolchain go1.23.2
+go 1.21
 
 require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
-	github.com/np-guard/models v0.5.1
+	github.com/np-guard/models v0.3.4
 	github.com/openshift/api v0.0.0-20230502160752-c71432710382
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/np-guard/models v0.5.1 h1:qxewCB3cBLkBdcpMk05gKJkV1D7qkbteQdIXbN1juW0=
-github.com/np-guard/models v0.5.1/go.mod h1:29M8utxinyUpYaDuIuOyCcMBf7EsMWZcIrRWCjFm0Bw=
+github.com/np-guard/models v0.3.4 h1:HOhVi6wyGvo+KmYBnQ5Km5HYCF+/PQlDs1v7mL1v05g=
+github.com/np-guard/models v0.3.4/go.mod h1:mqE2Irf8r+7HWh8fII0fWbWyQRMHGEo2SgSLN/6VKs8=
 github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4=
 github.com/onsi/ginkgo/v2 v2.13.0/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=
 github.com/onsi/gomega v1.29.0 h1:KIA/t2t5UBzoirT4H9tsML45GEbo3ouUnBHsCfD2tVg=

--- a/pkg/netpol/eval/check.go
+++ b/pkg/netpol/eval/check.go
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/np-guard/models/pkg/netset"
+	"github.com/np-guard/models/pkg/ipblock"
 
 	"github.com/np-guard/netpol-analyzer/pkg/internal/netpolerrors"
 	"github.com/np-guard/netpol-analyzer/pkg/netpol/eval/internal/k8s"
@@ -339,7 +339,7 @@ func updatePeerXgressClusterWideExposure(policy *k8s.NetworkPolicy, src, dst k8s
 // isPeerNodeIP returns true if peer1 is an IP address of a node and peer2 is a pod on that node
 func isPeerNodeIP(peer1, peer2 k8s.Peer) bool {
 	if peer2.PeerType() == k8s.PodType && peer1.PeerType() == k8s.IPBlockType {
-		ip2, err := netset.IPBlockFromIPAddress(peer2.GetPeerPod().HostIP)
+		ip2, err := ipblock.FromIPAddress(peer2.GetPeerPod().HostIP)
 		if err != nil {
 			return peer1.GetPeerIPBlock().Equal(ip2)
 		}
@@ -362,7 +362,7 @@ func isPodToItself(peer1, peer2 k8s.Peer) bool {
 func (pe *PolicyEngine) getPeer(p string) (k8s.Peer, error) {
 	// check if input peer is cidr
 	if _, _, err := net.ParseCIDR(p); err == nil {
-		peerIPBlock, err := netset.IPBlockFromCidr(p)
+		peerIPBlock, err := ipblock.FromCidr(p)
 		if err != nil {
 			return nil, err
 		}
@@ -370,7 +370,7 @@ func (pe *PolicyEngine) getPeer(p string) (k8s.Peer, error) {
 	}
 	// check if input peer is an ip address
 	if net.ParseIP(p) != nil {
-		peerIPBlock, err := netset.IPBlockFromIPAddress(p)
+		peerIPBlock, err := ipblock.FromIPAddress(p)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/netpol/eval/internal/k8s/netpol.go
+++ b/pkg/netpol/eval/internal/k8s/netpol.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/np-guard/models/pkg/netset"
+	"github.com/np-guard/models/pkg/ipblock"
 
 	"github.com/np-guard/netpol-analyzer/pkg/internal/netpolerrors"
 	"github.com/np-guard/netpol-analyzer/pkg/netpol/internal/common"
@@ -263,7 +263,7 @@ func (np *NetworkPolicy) ruleSelectsPeer(rulePeers []netv1.NetworkPolicyPeer, pe
 			}
 
 			peerIPBlock := peer.GetPeerIPBlock()
-			res := peerIPBlock.IsSubset(ruleIPBlock)
+			res := peerIPBlock.ContainedIn(ruleIPBlock)
 			if res {
 				return true, nil
 			}
@@ -397,8 +397,8 @@ func (np *NetworkPolicy) netpolErr(title, description string) error {
 	return fmt.Errorf("network policy %s %s: %s", np.fullName(), title, description)
 }
 
-func (np *NetworkPolicy) parseNetpolCIDR(cidr string, except []string) (*netset.IPBlock, error) {
-	ipb, err := netset.IPBlockFromCidr(cidr)
+func (np *NetworkPolicy) parseNetpolCIDR(cidr string, except []string) (*ipblock.IPBlock, error) {
+	ipb, err := ipblock.FromCidr(cidr)
 	if err != nil {
 		return nil, np.netpolErr(netpolerrors.CidrErrTitle, err.Error())
 	}
@@ -417,8 +417,8 @@ func (np *NetworkPolicy) parseNetpolLabelSelector(selector *metav1.LabelSelector
 	return selectorRes, nil
 }
 
-func (np *NetworkPolicy) rulePeersReferencedIPBlocks(rulePeers []netv1.NetworkPolicyPeer) ([]*netset.IPBlock, error) {
-	res := []*netset.IPBlock{}
+func (np *NetworkPolicy) rulePeersReferencedIPBlocks(rulePeers []netv1.NetworkPolicyPeer) ([]*ipblock.IPBlock, error) {
+	res := []*ipblock.IPBlock{}
 	for _, peerObj := range rulePeers {
 		if peerObj.IPBlock != nil {
 			ipb, err := np.parseNetpolCIDR(peerObj.IPBlock.CIDR, peerObj.IPBlock.Except)
@@ -432,8 +432,8 @@ func (np *NetworkPolicy) rulePeersReferencedIPBlocks(rulePeers []netv1.NetworkPo
 }
 
 // GetReferencedIPBlocks: return list of IPBlock objects referenced in the current network policy
-func (np *NetworkPolicy) GetReferencedIPBlocks() ([]*netset.IPBlock, error) {
-	res := []*netset.IPBlock{}
+func (np *NetworkPolicy) GetReferencedIPBlocks() ([]*ipblock.IPBlock, error) {
+	res := []*ipblock.IPBlock{}
 	for _, rule := range np.Spec.Ingress {
 		ruleRes, err := np.rulePeersReferencedIPBlocks(rule.From)
 		if err != nil {

--- a/pkg/netpol/eval/internal/k8s/peer.go
+++ b/pkg/netpol/eval/internal/k8s/peer.go
@@ -9,7 +9,7 @@ package k8s
 import (
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/np-guard/models/pkg/netset"
+	"github.com/np-guard/models/pkg/ipblock"
 )
 
 // PeerType is a type to indicate the type of a Peer object (Pod or IP address)
@@ -32,7 +32,7 @@ type Peer interface {
 	// else returns nil
 	GetPeerNamespace() *Namespace
 	// GetPeerIPBlock returns a reference to IPBlock if the peer is IP address, else returns nil
-	GetPeerIPBlock() *netset.IPBlock
+	GetPeerIPBlock() *ipblock.IPBlock
 }
 
 // PodPeer implements k8s.Peer interface and eval.Peer interface
@@ -43,7 +43,7 @@ type PodPeer struct {
 
 // IPBlockPeer implements k8s.Peer interface and eval.Peer interface
 type IPBlockPeer struct {
-	IPBlock *netset.IPBlock
+	IPBlock *ipblock.IPBlock
 }
 
 // WorkloadPeer implements eval.Peer interface
@@ -118,7 +118,7 @@ func (p *PodPeer) GetPeerNamespace() *Namespace {
 	return p.NamespaceObject
 }
 
-func (p *PodPeer) GetPeerIPBlock() *netset.IPBlock {
+func (p *PodPeer) GetPeerIPBlock() *ipblock.IPBlock {
 	return nil
 }
 
@@ -160,7 +160,7 @@ func (p *IPBlockPeer) GetPeerNamespace() *Namespace {
 	return nil
 }
 
-func (p *IPBlockPeer) GetPeerIPBlock() *netset.IPBlock {
+func (p *IPBlockPeer) GetPeerIPBlock() *ipblock.IPBlock {
 	return p.IPBlock
 }
 

--- a/pkg/netpol/eval/peer.go
+++ b/pkg/netpol/eval/peer.go
@@ -9,7 +9,7 @@ package eval
 import (
 	"fmt"
 
-	"github.com/np-guard/models/pkg/netset"
+	"github.com/np-guard/models/pkg/ipblock"
 
 	"github.com/np-guard/netpol-analyzer/pkg/netpol/eval/internal/k8s"
 )
@@ -35,7 +35,7 @@ type Peer interface {
 // then in the result map there would be entries for (str(A), str(A1), A1) and for (str(A), str(A2), A2)
 func DisjointPeerIPMap(set1, set2 []Peer) (map[string]map[string]Peer, error) {
 	res := map[string]map[string]Peer{}
-	var ipSet1, ipSet2 []*netset.IPBlock
+	var ipSet1, ipSet2 []*ipblock.IPBlock
 	var err error
 	if ipSet1, err = peerIPSetToIPBlockSet(set1); err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func DisjointPeerIPMap(set1, set2 []Peer) (map[string]map[string]Peer, error) {
 	if ipSet2, err = peerIPSetToIPBlockSet(set2); err != nil {
 		return nil, err
 	}
-	disjointIPset := netset.DisjointIPBlocks(ipSet1, ipSet2)
+	disjointIPset := ipblock.DisjointIPBlocks(ipSet1, ipSet2)
 
 	for _, ipb := range disjointIPset {
 		addDisjointIPBlockToMap(ipSet1, ipb, res)
@@ -54,9 +54,9 @@ func DisjointPeerIPMap(set1, set2 []Peer) (map[string]map[string]Peer, error) {
 }
 
 // addDisjointIPBlockToMap updates input map (from peer-str to its disjoint peers) by adding a new disjoint ip
-func addDisjointIPBlockToMap(ipSet []*netset.IPBlock, disjointIP *netset.IPBlock, m map[string]map[string]Peer) {
+func addDisjointIPBlockToMap(ipSet []*ipblock.IPBlock, disjointIP *ipblock.IPBlock, m map[string]map[string]Peer) {
 	for _, ipb1 := range ipSet {
-		if disjointIP.IsSubset(ipb1) {
+		if disjointIP.ContainedIn(ipb1) {
 			updatePeerIPMap(m, ipb1, disjointIP)
 			break
 		}
@@ -65,7 +65,7 @@ func addDisjointIPBlockToMap(ipSet []*netset.IPBlock, disjointIP *netset.IPBlock
 
 // updatePeerIPMap updates input map (from peer-str to its disjoint peers), given a new disjoint ip (ipb), and its
 // associated original ip-range key from the map (ipb1)
-func updatePeerIPMap(m map[string]map[string]Peer, ipb1, ipb *netset.IPBlock) {
+func updatePeerIPMap(m map[string]map[string]Peer, ipb1, ipb *ipblock.IPBlock) {
 	ipb1Str := ipb1.ToIPRanges()
 	if _, ok := m[ipb1Str]; !ok {
 		m[ipb1Str] = map[string]Peer{}
@@ -74,8 +74,8 @@ func updatePeerIPMap(m map[string]map[string]Peer, ipb1, ipb *netset.IPBlock) {
 }
 
 // peerIPSetToIPBlockSet is given as input a list of peers of type ip-block, and returns a list matching IPBlock objects
-func peerIPSetToIPBlockSet(peerSet []Peer) ([]*netset.IPBlock, error) {
-	res := make([]*netset.IPBlock, len(peerSet))
+func peerIPSetToIPBlockSet(peerSet []Peer) ([]*ipblock.IPBlock, error) {
+	res := make([]*ipblock.IPBlock, len(peerSet))
 	for i, p := range peerSet {
 		ipBlock, err := peerIPToIPBlock(p)
 		if err != nil {
@@ -87,7 +87,7 @@ func peerIPSetToIPBlockSet(peerSet []Peer) ([]*netset.IPBlock, error) {
 }
 
 // peerIPToIPBlock returns an IPBlock object from a Peer object of IP type
-func peerIPToIPBlock(p Peer) (*netset.IPBlock, error) {
+func peerIPToIPBlock(p Peer) (*ipblock.IPBlock, error) {
 	peerIP, ok := p.(*k8s.IPBlockPeer)
 	if !ok {
 		return nil, fmt.Errorf("input peer not IP block: %s", p.String())
@@ -95,9 +95,9 @@ func peerIPToIPBlock(p Peer) (*netset.IPBlock, error) {
 	return peerIP.IPBlock, nil
 }
 
-func mergeIPBlocksList(inputList []*netset.IPBlock) []*netset.IPBlock {
+func mergeIPBlocksList(inputList []*ipblock.IPBlock) []*ipblock.IPBlock {
 	if len(inputList) == 0 {
-		return []*netset.IPBlock{}
+		return []*ipblock.IPBlock{}
 	}
 	union := inputList[0].Copy()
 	for i := 1; i < len(inputList); i++ {

--- a/pkg/netpol/eval/resources.go
+++ b/pkg/netpol/eval/resources.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/np-guard/models/pkg/netset"
+	"github.com/np-guard/models/pkg/ipblock"
 
 	"github.com/np-guard/netpol-analyzer/pkg/internal/netpolerrors"
 	"github.com/np-guard/netpol-analyzer/pkg/manifests/parser"
@@ -542,8 +542,8 @@ func (pe *PolicyEngine) GetRepresentativePeersList() []Peer {
 }
 
 // getDisjointIPBlocks returns a slice of disjoint ip-blocks from all netpols resources
-func (pe *PolicyEngine) getDisjointIPBlocks() ([]*netset.IPBlock, error) {
-	var ipbList []*netset.IPBlock
+func (pe *PolicyEngine) getDisjointIPBlocks() ([]*ipblock.IPBlock, error) {
+	var ipbList []*ipblock.IPBlock
 	for _, nsMap := range pe.netpolsMap {
 		for _, policy := range nsMap {
 			policyIPBlocksList, err := policy.GetReferencedIPBlocks()
@@ -553,8 +553,8 @@ func (pe *PolicyEngine) getDisjointIPBlocks() ([]*netset.IPBlock, error) {
 			ipbList = append(ipbList, policyIPBlocksList...)
 		}
 	}
-	newAll := netset.GetCidrAll()
-	disjointRes := netset.DisjointIPBlocks(ipbList, []*netset.IPBlock{newAll})
+	newAll := ipblock.GetCidrAll()
+	disjointRes := ipblock.DisjointIPBlocks(ipbList, []*ipblock.IPBlock{newAll})
 	return disjointRes, nil
 }
 

--- a/pkg/netpol/internal/common/portset.go
+++ b/pkg/netpol/internal/common/portset.go
@@ -105,7 +105,7 @@ func (p *PortSet) Union(other *PortSet) {
 
 // ContainedIn: return true if current PortSet object is contained in input PortSet object
 func (p *PortSet) ContainedIn(other *PortSet) bool {
-	return p.Ports.IsSubset(other.Ports)
+	return p.Ports.ContainedIn(other.Ports)
 }
 
 // Intersection: update current PortSet object as intersection with input PortSet object


### PR DESCRIPTION
This reverts commit cf5866f3e409c44ead7136a6e7ec91be9a1460c2.