### PR TITLE
issue 478 : simulate live cluster tests

### DIFF
--- a/pkg/netpol/connlist/connlist.go
+++ b/pkg/netpol/connlist/connlist.go
@@ -368,8 +368,8 @@ func (ca *ConnlistAnalyzer) connsListFromParsedResources(objectsList []parser.K8
 }
 
 // ConnlistFromK8sClusterWithPolicyAPI returns the allowed connections list from k8s cluster resources, and list of all peers names
-func (ca *ConnlistAnalyzer) ConnlistFromK8sClusterWithPolicyAPI(clientset *kubernetes.Clientset,
-	policyAPIClientset *policyapi.Clientset) ([]Peer2PeerConnection, []Peer, error) {
+func (ca *ConnlistAnalyzer) ConnlistFromK8sClusterWithPolicyAPI(clientset kubernetes.Interface,
+	policyAPIClientset policyapi.Interface) ([]Peer2PeerConnection, []Peer, error) {
 	pe, err := eval.NewPolicyEngineWithOptionsList(eval.WithExplanation(ca.explain), eval.WithLogger(ca.logger))
 	if ca.exposureAnalysis {
 		pe, err = eval.NewPolicyEngineWithOptionsList(eval.WithExposureAnalysis(), eval.WithExplanation(ca.explain), eval.WithLogger(ca.logger))
@@ -392,7 +392,7 @@ func (ca *ConnlistAnalyzer) ConnlistFromK8sClusterWithPolicyAPI(clientset *kuber
 }
 
 // updatePolicyEngineWithK8sBasicObjects inserts to the policy engine all k8s pods, namespaces and network-policies
-func updatePolicyEngineWithK8sBasicObjects(pe *eval.PolicyEngine, clientset *kubernetes.Clientset) error {
+func updatePolicyEngineWithK8sBasicObjects(pe *eval.PolicyEngine, clientset kubernetes.Interface) error {
 	ctx, cancel := context.WithTimeout(context.Background(), pkgcommon.CtxTimeoutSeconds*time.Second)
 	defer cancel()
 	// get all namespaces

--- a/pkg/netpol/connlist/connlist.go
+++ b/pkg/netpol/connlist/connlist.go
@@ -372,7 +372,8 @@ func (ca *ConnlistAnalyzer) ConnlistFromK8sClusterWithPolicyAPI(clientset kubern
 	policyAPIClientset policyapi.Interface) ([]Peer2PeerConnection, []Peer, error) {
 	pe, err := eval.NewPolicyEngineWithOptionsList(eval.WithExplanation(ca.explain), eval.WithLogger(ca.logger))
 	if ca.exposureAnalysis {
-		pe, err = eval.NewPolicyEngineWithOptionsList(eval.WithExposureAnalysis(), eval.WithExplanation(ca.explain), eval.WithLogger(ca.logger))
+		ca.logWarning(alerts.WarnIgnoredExposureOnLiveCluster)
+		ca.exposureAnalysis = false
 	}
 	if err != nil {
 		return nil, nil, err

--- a/pkg/netpol/connlist/connlist_mock_k8s_server_test.go
+++ b/pkg/netpol/connlist/connlist_mock_k8s_server_test.go
@@ -1,0 +1,284 @@
+/*
+Copyright 2023- IBM Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package connlist
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
+
+	policyapifake "sigs.k8s.io/network-policy-api/pkg/client/clientset/versioned/fake"
+
+	"github.com/np-guard/netpol-analyzer/pkg/internal/output"
+	"github.com/np-guard/netpol-analyzer/pkg/internal/testutils"
+	"github.com/np-guard/netpol-analyzer/pkg/logger"
+	"github.com/np-guard/netpol-analyzer/pkg/manifests/fsscanner"
+	"github.com/np-guard/netpol-analyzer/pkg/manifests/parser"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	apisv1a "sigs.k8s.io/network-policy-api/apis/v1alpha1"
+
+	ocroutev1 "github.com/openshift/api/route/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestConnlistOnMockK8sServer(t *testing.T) {
+	for _, tt := range liveClusterTestingPaths {
+		t.Run(tt.testDirName, func(t *testing.T) {
+			for _, format := range tt.outputFormats {
+				pTest := prepareTest(tt.testDirName, tt.focusWorkloads, tt.focusWorkloadPeers, tt.focusDirection, tt.focusConn,
+					format, tt.exposureAnalysis)
+				infos, _ := fsscanner.GetResourceInfosFromDirPath([]string{pTest.dirPath}, true, false)
+				objects, _ := parser.ResourceInfoListToK8sObjectsList(infos, logger.NewDefaultLogger(), true)
+
+				k8sClientset, policyAPIClientset, err := buildFakeClientsets(objects)
+				require.Nil(t, err, pTest.testInfo)
+
+				// run connlist API funcs for connectivity analysis on live cluster
+				res, _, err := pTest.analyzer.ConnlistFromK8sClusterWithPolicyAPI(k8sClientset, policyAPIClientset)
+				require.Nil(t, err, pTest.testInfo)
+				out, err := pTest.analyzer.ConnectionsListToString(res)
+				require.Nil(t, err, pTest.testInfo)
+				testutils.CheckActualVsExpectedOutputMatch(t, pTest.expectedOutputFileName, out,
+					pTest.testInfo, currentPkg)
+			}
+		})
+	}
+}
+
+func buildFakeClientsets(objects []parser.K8sObject) (k8sClientset *fake.Clientset, policyAPIClientset *policyapifake.Clientset,
+	err error) {
+	// register a custom runtime scheme
+	sch := runtime.NewScheme()
+	err = registerScheme(sch)
+	if err != nil {
+		return nil, nil, err
+	}
+	// build simple fake clientset(s)
+	k8sClientset = fake.NewSimpleClientset()
+	policyAPIClientset = policyapifake.NewSimpleClientset()
+	// add objects to the clientset(s)
+	addObjectsByKindToClientsets(k8sClientset, policyAPIClientset, objects)
+	return k8sClientset, policyAPIClientset, nil
+}
+
+//nolint:errcheck // all objects are valid
+func addObjectsByKindToClientsets(k8sClientset *fake.Clientset, policyAPIClientset *policyapifake.Clientset,
+	objects []parser.K8sObject) {
+	for i := range objects {
+		obj := objects[i]
+		switch obj.Kind {
+		case parser.Namespace:
+			k8sClientset.CoreV1().Namespaces().Create(context.TODO(), obj.Namespace, metav1.CreateOptions{})
+		case parser.NetworkPolicy:
+			k8sClientset.NetworkingV1().NetworkPolicies(obj.NetworkPolicy.Namespace).Create(context.TODO(), obj.NetworkPolicy,
+				metav1.CreateOptions{})
+		case parser.AdminNetworkPolicy:
+			policyAPIClientset.PolicyV1alpha1().AdminNetworkPolicies().Create(context.TODO(), obj.AdminNetworkPolicy,
+				metav1.CreateOptions{})
+		case parser.BaselineAdminNetworkPolicy:
+			policyAPIClientset.PolicyV1alpha1().BaselineAdminNetworkPolicies().Create(context.TODO(), obj.BaselineAdminNetworkPolicy,
+				metav1.CreateOptions{})
+		case parser.Pod:
+			k8sClientset.CoreV1().Pods(obj.Pod.Namespace).Create(context.TODO(), obj.Pod, metav1.CreateOptions{})
+		// todo: if `ConnlistFromK8sClusterWithPolicyAPI` is changed to support following objects kinds, then uncomment those lines
+		// case parser.ReplicaSet:
+		// 	k8sClientset.AppsV1().ReplicaSets(obj.ReplicaSet.Namespace).Create(context.TODO(), obj.ReplicaSet, metav1.CreateOptions{})
+		// case parser.ReplicationController:
+		// 	k8sClientset.CoreV1().ReplicationControllers(obj.ReplicationController.Namespace).Create(context.TODO(),
+		// 		obj.ReplicationController, metav1.CreateOptions{})
+		// case parser.Deployment:
+		// 	k8sClientset.AppsV1().Deployments(obj.Deployment.Namespace).Create(context.TODO(), obj.Deployment, metav1.CreateOptions{})
+		// case parser.StatefulSet:
+		// 	k8sClientset.AppsV1().StatefulSets(obj.StatefulSet.Namespace).Create(context.TODO(), obj.StatefulSet, metav1.CreateOptions{})
+		// case parser.DaemonSet:
+		// 	k8sClientset.AppsV1().DaemonSets(obj.DaemonSet.Namespace).Create(context.TODO(), obj.DaemonSet, metav1.CreateOptions{})
+		// case parser.Job:
+		// 	k8sClientset.BatchV1().Jobs(obj.Job.Namespace).Create(context.TODO(), obj.Job, metav1.CreateOptions{})
+		// case parser.CronJob:
+		// 	k8sClientset.BatchV1().CronJobs(obj.CronJob.Namespace).Create(context.TODO(), obj.CronJob, metav1.CreateOptions{})
+		// case parser.Service:
+		// 	k8sClientset.CoreV1().Services(obj.Service.Namespace).Create(context.TODO(), obj.Service, metav1.CreateOptions{})
+		// case parser.Route:
+		// case parser.Ingress:
+		default:
+			continue
+		}
+	}
+}
+
+// registerScheme registers needed API types, so we can create after then a fake clientset with parsed objects
+func registerScheme(sch *runtime.Scheme) error {
+	err := appsv1.AddToScheme(sch)
+	if err != nil {
+		return err
+	}
+	err = batchv1.AddToScheme(sch)
+	if err != nil {
+		return err
+	}
+	err = v1.AddToScheme(sch)
+	if err != nil {
+		return err
+	}
+	err = netv1.AddToScheme(sch)
+	if err != nil {
+		return err
+	}
+	err = apisv1a.AddToScheme(sch)
+	if err != nil {
+		return err
+	}
+	err = ocroutev1.AddToScheme(sch)
+	if err != nil {
+		return err
+	}
+	return metav1.AddMetaToScheme(sch)
+}
+
+var liveClusterTestingPaths = []struct {
+	testDirName        string
+	outputFormats      []string
+	focusWorkloads     []string
+	focusWorkloadPeers []string
+	focusDirection     string
+	focusConn          string
+	exposureAnalysis   bool
+}{
+	{
+		testDirName:   "ipblockstest",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "onlineboutique",
+		outputFormats: []string{output.JSONFormat, output.MDFormat, output.TextFormat},
+	},
+	{
+		testDirName:   "minikube_resources",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "core_pods_without_host_ip",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "test_with_named_ports",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "test_with_named_ports_changed_netpol",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "with_end_port_example",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "with_end_port_example_new",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "multiple_topology_resources_1",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "multiple_topology_resources_2",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "multiple_topology_resources_3",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "multiple_topology_resources_4",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "semanticDiff-same-topologies-old1",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "semanticDiff-same-topologies-old2",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "semanticDiff-same-topologies-old3",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "semanticDiff-same-topologies-new1",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "semanticDiff-same-topologies-new1a",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "semanticDiff-same-topologies-new2",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "semanticDiff-same-topologies-new3",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "semanticDiff-orig-topologies-no-policy",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "semanticDiff-orig-topologies-policy-a",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "semanticDiff-different-topologies-policy-a",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "semanticDiff-different-topologies-policy-b",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "ipblockstest_2",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "ipblockstest_3",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "ipblockstest_4",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "semanticDiff-different-topologies-policy-a-with-ipblock",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "semanticDiff-different-topologies-policy-b-with-ipblock",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "test_with_named_ports_changed_netpol_2",
+		outputFormats: []string{output.TextFormat},
+	},
+	{
+		testDirName:   "anp_banp_blog_demo",
+		outputFormats: ValidFormats,
+	},
+	{
+		testDirName:    "anp_banp_blog_demo",
+		focusWorkloads: []string{"myfoo", "mybar"},
+		outputFormats:  ValidFormats,
+	},
+}

--- a/pkg/netpol/connlist/connlist_mock_k8s_server_test.go
+++ b/pkg/netpol/connlist/connlist_mock_k8s_server_test.go
@@ -17,7 +17,6 @@ import (
 
 	policyapifake "sigs.k8s.io/network-policy-api/pkg/client/clientset/versioned/fake"
 
-	"github.com/np-guard/netpol-analyzer/pkg/internal/output"
 	"github.com/np-guard/netpol-analyzer/pkg/internal/testutils"
 	"github.com/np-guard/netpol-analyzer/pkg/logger"
 	"github.com/np-guard/netpol-analyzer/pkg/manifests/fsscanner"
@@ -34,8 +33,13 @@ import (
 )
 
 func TestConnlistOnMockK8sServer(t *testing.T) {
-	for _, tt := range liveClusterTestingPaths {
+	t.Parallel()
+	for _, tt := range goodPathTests {
+		if !tt.supportedOnLiveCluster {
+			continue
+		}
 		t.Run(tt.testDirName, func(t *testing.T) {
+			t.Parallel()
 			for _, format := range tt.outputFormats {
 				pTest := prepareTest(tt.testDirName, tt.focusWorkloads, tt.focusWorkloadPeers, tt.focusDirection, tt.focusConn,
 					format, tt.exposureAnalysis)
@@ -145,140 +149,4 @@ func registerScheme(sch *runtime.Scheme) error {
 		return err
 	}
 	return metav1.AddMetaToScheme(sch)
-}
-
-var liveClusterTestingPaths = []struct {
-	testDirName        string
-	outputFormats      []string
-	focusWorkloads     []string
-	focusWorkloadPeers []string
-	focusDirection     string
-	focusConn          string
-	exposureAnalysis   bool
-}{
-	{
-		testDirName:   "ipblockstest",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "onlineboutique",
-		outputFormats: []string{output.JSONFormat, output.MDFormat, output.TextFormat},
-	},
-	{
-		testDirName:   "minikube_resources",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "core_pods_without_host_ip",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "test_with_named_ports",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "test_with_named_ports_changed_netpol",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "with_end_port_example",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "with_end_port_example_new",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "multiple_topology_resources_1",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "multiple_topology_resources_2",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "multiple_topology_resources_3",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "multiple_topology_resources_4",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "semanticDiff-same-topologies-old1",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "semanticDiff-same-topologies-old2",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "semanticDiff-same-topologies-old3",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "semanticDiff-same-topologies-new1",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "semanticDiff-same-topologies-new1a",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "semanticDiff-same-topologies-new2",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "semanticDiff-same-topologies-new3",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "semanticDiff-orig-topologies-no-policy",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "semanticDiff-orig-topologies-policy-a",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "semanticDiff-different-topologies-policy-a",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "semanticDiff-different-topologies-policy-b",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "ipblockstest_2",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "ipblockstest_3",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "ipblockstest_4",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "semanticDiff-different-topologies-policy-a-with-ipblock",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "semanticDiff-different-topologies-policy-b-with-ipblock",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "test_with_named_ports_changed_netpol_2",
-		outputFormats: []string{output.TextFormat},
-	},
-	{
-		testDirName:   "anp_banp_blog_demo",
-		outputFormats: ValidFormats,
-	},
-	{
-		testDirName:    "anp_banp_blog_demo",
-		focusWorkloads: []string{"myfoo", "mybar"},
-		outputFormats:  ValidFormats,
-	},
 }

--- a/pkg/netpol/connlist/connlist_test.go
+++ b/pkg/netpol/connlist/connlist_test.go
@@ -875,37 +875,42 @@ func TestConnlistOutputFatalErrors(t *testing.T) {
 }
 
 var goodPathTests = []struct {
-	testDirName        string
-	outputFormats      []string
-	focusWorkloads     []string
-	focusWorkloadPeers []string
-	focusDirection     string
-	focusConn          string
-	exposureAnalysis   bool
+	testDirName            string
+	outputFormats          []string
+	focusWorkloads         []string
+	focusWorkloadPeers     []string
+	focusDirection         string
+	focusConn              string
+	exposureAnalysis       bool
+	supportedOnLiveCluster bool
 }{
 	{
-		testDirName:   "ipblockstest",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "ipblockstest",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "onlineboutique",
-		outputFormats: []string{output.JSONFormat, output.MDFormat, output.TextFormat},
+		testDirName:            "onlineboutique",
+		outputFormats:          []string{output.JSONFormat, output.MDFormat, output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
 		testDirName:   "onlineboutique_workloads",
 		outputFormats: []string{output.CSVFormat, output.DOTFormat, output.TextFormat},
 	},
 	{
-		testDirName:   "minikube_resources",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "minikube_resources",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
 		testDirName:   "online_boutique_workloads_no_ns",
 		outputFormats: []string{output.TextFormat},
 	},
 	{
-		testDirName:   "core_pods_without_host_ip",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "core_pods_without_host_ip",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
 		testDirName:   "acs_security_frontend_demos",
@@ -940,24 +945,28 @@ var goodPathTests = []struct {
 		outputFormats: []string{output.TextFormat},
 	},
 	{
-		testDirName:   "test_with_named_ports",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "test_with_named_ports",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "test_with_named_ports_changed_netpol",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "test_with_named_ports_changed_netpol",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
 		testDirName:   "netpol-analysis-example-minimal",
 		outputFormats: ValidFormats,
 	},
 	{
-		testDirName:   "with_end_port_example",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "with_end_port_example",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "with_end_port_example_new",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "with_end_port_example_new",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
 		testDirName:   "new_online_boutique",
@@ -968,92 +977,113 @@ var goodPathTests = []struct {
 		outputFormats: []string{output.TextFormat},
 	},
 	{
-		testDirName:   "multiple_topology_resources_1",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "multiple_topology_resources_1",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "multiple_topology_resources_2",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "multiple_topology_resources_2",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "multiple_topology_resources_3",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "multiple_topology_resources_3",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "multiple_topology_resources_4",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "multiple_topology_resources_4",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
 		testDirName:   "minimal_test_in_ns",
 		outputFormats: []string{output.TextFormat},
 	},
 	{
-		testDirName:   "semanticDiff-same-topologies-old1",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "semanticDiff-same-topologies-old1",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "semanticDiff-same-topologies-old2",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "semanticDiff-same-topologies-old2",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "semanticDiff-same-topologies-old3",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "semanticDiff-same-topologies-old3",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "semanticDiff-same-topologies-new1",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "semanticDiff-same-topologies-new1",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "semanticDiff-same-topologies-new1a",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "semanticDiff-same-topologies-new1a",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "semanticDiff-same-topologies-new2",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "semanticDiff-same-topologies-new2",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "semanticDiff-same-topologies-new3",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "semanticDiff-same-topologies-new3",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "semanticDiff-orig-topologies-no-policy",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "semanticDiff-orig-topologies-no-policy",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "semanticDiff-orig-topologies-policy-a",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "semanticDiff-orig-topologies-policy-a",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "semanticDiff-different-topologies-policy-a",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "semanticDiff-different-topologies-policy-a",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "semanticDiff-different-topologies-policy-b",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "semanticDiff-different-topologies-policy-b",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "ipblockstest_2",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "ipblockstest_2",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "ipblockstest_3",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "ipblockstest_3",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "ipblockstest_4",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "ipblockstest_4",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "semanticDiff-different-topologies-policy-a-with-ipblock",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "semanticDiff-different-topologies-policy-a-with-ipblock",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "semanticDiff-different-topologies-policy-b-with-ipblock",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "semanticDiff-different-topologies-policy-b-with-ipblock",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:   "test_with_named_ports_changed_netpol_2",
-		outputFormats: []string{output.TextFormat},
+		testDirName:            "test_with_named_ports_changed_netpol_2",
+		outputFormats:          []string{output.TextFormat},
+		supportedOnLiveCluster: true,
 	},
 	{
 		testDirName:    "onlineboutique_workloads",
@@ -1698,8 +1728,9 @@ var goodPathTests = []struct {
 		outputFormats: ValidFormats,
 	},
 	{
-		testDirName:   "anp_banp_blog_demo",
-		outputFormats: ValidFormats,
+		testDirName:            "anp_banp_blog_demo",
+		outputFormats:          ValidFormats,
+		supportedOnLiveCluster: true,
 	},
 	{
 		testDirName:   "anp_and_banp_using_networks_test",
@@ -1881,9 +1912,10 @@ var goodPathTests = []struct {
 	},
 	// tests with multiple workloads
 	{
-		testDirName:    "anp_banp_blog_demo",
-		focusWorkloads: []string{"myfoo", "mybar"},
-		outputFormats:  ValidFormats,
+		testDirName:            "anp_banp_blog_demo",
+		focusWorkloads:         []string{"myfoo", "mybar"},
+		outputFormats:          ValidFormats,
+		supportedOnLiveCluster: true,
 	},
 	{
 		testDirName:      "acs-security-demos",
@@ -1936,6 +1968,20 @@ var goodPathTests = []struct {
 		exposureAnalysis: true,
 		focusWorkloads:   []string{"harry-potter"},
 		focusDirection:   common.EgressFocusDirection,
+	},
+	{
+		testDirName:            "anp_banp_blog_demo",
+		focusConn:              "udp-52",
+		outputFormats:          []string{output.DefaultFormat},
+		supportedOnLiveCluster: true,
+	},
+	{
+		testDirName:            "anp_banp_blog_demo",
+		focusWorkloads:         []string{"mybar"},
+		focusWorkloadPeers:     []string{"mybaz"},
+		focusDirection:         common.EgressFocusDirection,
+		outputFormats:          []string{output.DefaultFormat},
+		supportedOnLiveCluster: true,
 	},
 }
 

--- a/pkg/netpol/connlist/explanation_test.go
+++ b/pkg/netpol/connlist/explanation_test.go
@@ -55,13 +55,14 @@ func prepareExplainTest(dirName string, focusWorkloads, focusWorkloadPeers []str
 }
 
 var explainTests = []struct {
-	testDirName        string
-	focusWorkloads     []string
-	focusDirection     string
-	focusConn          string
-	focusWorkloadPeers []string
-	exposure           bool
-	explainOnly        string
+	testDirName            string
+	focusWorkloads         []string
+	focusDirection         string
+	focusConn              string
+	focusWorkloadPeers     []string
+	exposure               bool
+	explainOnly            string
+	supportedOnLiveCluster bool
 }{
 	{
 		testDirName: "acs-security-demos",
@@ -70,12 +71,14 @@ var explainTests = []struct {
 		testDirName: "anp_and_banp_using_networks_and_nodes_test",
 	},
 	{
-		testDirName: "anp_banp_blog_demo",
+		testDirName:            "anp_banp_blog_demo",
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:    "anp_banp_blog_demo",
-		focusWorkloads: []string{"myfoo"},
-		focusDirection: common.IngressFocusDirection,
+		testDirName:            "anp_banp_blog_demo",
+		focusWorkloads:         []string{"myfoo"},
+		focusDirection:         common.IngressFocusDirection,
+		supportedOnLiveCluster: true,
 	},
 	{
 		testDirName: "anp_banp_blog_demo_2",
@@ -96,7 +99,8 @@ var explainTests = []struct {
 		testDirName: "demo_app_with_routes_and_ingress",
 	},
 	{
-		testDirName: "ipblockstest",
+		testDirName:            "ipblockstest",
+		supportedOnLiveCluster: true,
 	},
 	{
 		testDirName: "k8s_ingress_test_new",
@@ -105,7 +109,8 @@ var explainTests = []struct {
 		testDirName: "multiple_ingress_objects_with_different_ports_new",
 	},
 	{
-		testDirName: "multiple_topology_resources_2",
+		testDirName:            "multiple_topology_resources_2",
+		supportedOnLiveCluster: true,
 	},
 	{
 		testDirName: "netpol_named_port_test",
@@ -114,7 +119,8 @@ var explainTests = []struct {
 		testDirName: "new_online_boutique",
 	},
 	{
-		testDirName: "onlineboutique",
+		testDirName:            "onlineboutique",
+		supportedOnLiveCluster: true,
 	},
 	{
 		testDirName: "onlineboutique_workloads_with_ingress",
@@ -243,36 +249,42 @@ var explainTests = []struct {
 		focusDirection: common.IngressFocusDirection,
 	},
 	{
-		testDirName:    "anp_banp_blog_demo",
-		focusWorkloads: []string{"mymonitoring", "mybaz"},
+		testDirName:            "anp_banp_blog_demo",
+		focusWorkloads:         []string{"mymonitoring", "mybaz"},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:        "anp_banp_blog_demo",
-		focusWorkloads:     []string{"mymonitoring"},
-		focusWorkloadPeers: []string{"myfoo"},
+		testDirName:            "anp_banp_blog_demo",
+		focusWorkloads:         []string{"mymonitoring"},
+		focusWorkloadPeers:     []string{"myfoo"},
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:        "anp_banp_blog_demo",
-		focusWorkloads:     []string{"myfoo", "mybar"},
-		focusWorkloadPeers: []string{"mybaz", "mymonitoring"},
-		focusDirection:     common.EgressFocusDirection,
+		testDirName:            "anp_banp_blog_demo",
+		focusWorkloads:         []string{"myfoo", "mybar"},
+		focusWorkloadPeers:     []string{"mybaz", "mymonitoring"},
+		focusDirection:         common.EgressFocusDirection,
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName: "anp_banp_blog_demo",
-		explainOnly: common.ExplainOnlyDeny,
+		testDirName:            "anp_banp_blog_demo",
+		explainOnly:            common.ExplainOnlyDeny,
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:        "anp_banp_blog_demo",
-		focusWorkloads:     []string{"mymonitoring"},
-		focusWorkloadPeers: []string{"myfoo"},
-		explainOnly:        common.ExplainOnlyAllow,
+		testDirName:            "anp_banp_blog_demo",
+		focusWorkloads:         []string{"mymonitoring"},
+		focusWorkloadPeers:     []string{"myfoo"},
+		explainOnly:            common.ExplainOnlyAllow,
+		supportedOnLiveCluster: true,
 	},
 	{
-		testDirName:        "anp_banp_blog_demo",
-		focusWorkloads:     []string{"mymonitoring"},
-		focusWorkloadPeers: []string{"myfoo"},
-		explainOnly:        common.ExplainOnlyAllow,
-		focusDirection:     common.EgressFocusDirection,
+		testDirName:            "anp_banp_blog_demo",
+		focusWorkloads:         []string{"mymonitoring"},
+		focusWorkloadPeers:     []string{"myfoo"},
+		explainOnly:            common.ExplainOnlyAllow,
+		focusDirection:         common.EgressFocusDirection,
+		supportedOnLiveCluster: true,
 	},
 	{
 		testDirName: "acs-security-demos",
@@ -280,12 +292,13 @@ var explainTests = []struct {
 		explainOnly: common.ExplainOnlyDeny,
 	},
 	{
-		testDirName:        "anp_banp_blog_demo",
-		focusWorkloads:     []string{"mymonitoring"},
-		focusWorkloadPeers: []string{"myfoo"},
-		explainOnly:        common.ExplainOnlyAllow,
-		focusDirection:     common.EgressFocusDirection,
-		focusConn:          "tcp-80",
+		testDirName:            "anp_banp_blog_demo",
+		focusWorkloads:         []string{"mymonitoring"},
+		focusWorkloadPeers:     []string{"myfoo"},
+		explainOnly:            common.ExplainOnlyAllow,
+		focusDirection:         common.EgressFocusDirection,
+		focusConn:              "tcp-80",
+		supportedOnLiveCluster: true,
 	},
 	{
 		testDirName: "acs-security-demos",

--- a/pkg/netpol/eval/resources.go
+++ b/pkg/netpol/eval/resources.go
@@ -275,7 +275,7 @@ func (pe *PolicyEngine) sortAdminNetpolsByPriority() error {
 }
 
 // UpdatePolicyEngineWithK8sPolicyAPIObjects inserts to the policy-engine all (baseline)admin network policies
-func (pe *PolicyEngine) UpdatePolicyEngineWithK8sPolicyAPIObjects(clientset *policyapi.Clientset) error {
+func (pe *PolicyEngine) UpdatePolicyEngineWithK8sPolicyAPIObjects(clientset policyapi.Interface) error {
 	ctx, cancel := context.WithTimeout(context.Background(), pkgcommon.CtxTimeoutSeconds*time.Second)
 	defer cancel()
 	// get all admin-network-policies

--- a/pkg/netpol/internal/alerts/warnings.go
+++ b/pkg/netpol/internal/alerts/warnings.go
@@ -38,6 +38,7 @@ const (
 	// tests/anp_and_banp_using_networks_with_ipv6_test
 	WarnUnsupportedNodesField = "Nodes field of an AdminNetworkPolicyEgressPeer is not supported" // example raising this
 	// warning: tests/anp_and_banp_using_networks_and_nodes_test
+	WarnIgnoredExposureOnLiveCluster = "exposure analysis is not supported on live-cluster; exposure flag will be ignored"
 )
 
 func WarnIgnoredExposure(flag1, flag2 string) string {

--- a/test_outputs/connlist/anp_banp_blog_demo_focus_workload_mybar_egress_with_mybaz_connlist_output.txt
+++ b/test_outputs/connlist/anp_banp_blog_demo_focus_workload_mybar_egress_with_mybaz_connlist_output.txt
@@ -1,0 +1,1 @@
+bar/mybar[Pod] => baz/mybaz[Pod] : All Connections

--- a/test_outputs/connlist/anp_banp_blog_demo_udp-52_connlist_output.txt
+++ b/test_outputs/connlist/anp_banp_blog_demo_udp-52_connlist_output.txt
@@ -1,0 +1,15 @@
+Permitted connections on UDP 52:
+0.0.0.0-255.255.255.255 => bar/mybar[Pod]
+0.0.0.0-255.255.255.255 => baz/mybaz[Pod]
+0.0.0.0-255.255.255.255 => monitoring/mymonitoring[Pod]
+bar/mybar[Pod] => 0.0.0.0-255.255.255.255
+bar/mybar[Pod] => baz/mybaz[Pod]
+bar/mybar[Pod] => monitoring/mymonitoring[Pod]
+baz/mybaz[Pod] => 0.0.0.0-255.255.255.255
+baz/mybaz[Pod] => monitoring/mymonitoring[Pod]
+foo/myfoo[Pod] => 0.0.0.0-255.255.255.255
+foo/myfoo[Pod] => baz/mybaz[Pod]
+foo/myfoo[Pod] => monitoring/mymonitoring[Pod]
+monitoring/mymonitoring[Pod] => 0.0.0.0-255.255.255.255
+monitoring/mymonitoring[Pod] => baz/mybaz[Pod]
+monitoring/mymonitoring[Pod] => foo/myfoo[Pod]


### PR DESCRIPTION
#478

- added a new test file that calls the API Func of ConnlistAnalyzer `ConnlistFromK8sClusterWithPolicyAPI` 
   which analyzes connectivity on live-cluster 
   
- the tests are on a mock server - i.e. the input clientsets of the API Func above are fake.

- the test func runs on a list of tests `liveClusterTestingPaths`  which contains only some of the `goodPathTests` in `connlist_test.go` 
and not all since:
           * the API Func `ConnlistFromK8sClusterWithPolicyAPI` supports only objects with kind: `Pod`, `Namespace`, `NetworkPolicy`, `AdminNetworkPolicy` and `BaselineAdminNetworkPolicy` 
            * and unlike "offline" connectivity analysis API funcs; `ConnlistFromK8sClusterWithPolicyAPI` does not support workload types objects, nether support `Ingress` and `Route` objects _(we can add support in another issue)_

- [x]  todo in next commit : add tests with more flags (like ~exposure~, focus-conn , etc...)

- [x] ~if support of workload types on live-cluster is not planned soon (may add tests with temp dirs with generated pod manifests from the workload manifests in the original dirs ( however can not do this to tests with  `Ingress` and `Route` objects)~

- [x] may use `goodPathTests`  instead of `liveClusterTestingPaths`  with flags to indicate if to skip the "un-matching" tests