### PR TITLE
support exposure-analysis on live-cluster 

### DIFF
--- a/pkg/netpol/connlist/connlist_test.go
+++ b/pkg/netpol/connlist/connlist_test.go
@@ -895,6 +895,12 @@ var goodPathTests = []struct {
 		supportedOnLiveCluster: true,
 	},
 	{
+		testDirName:            "onlineboutique",
+		outputFormats:          []string{output.MDFormat, output.TextFormat},
+		exposureAnalysis:       true,
+		supportedOnLiveCluster: true,
+	},
+	{
 		testDirName:   "onlineboutique_workloads",
 		outputFormats: []string{output.CSVFormat, output.DOTFormat, output.TextFormat},
 	},
@@ -1980,6 +1986,20 @@ var goodPathTests = []struct {
 		focusWorkloads:         []string{"mybar"},
 		focusWorkloadPeers:     []string{"mybaz"},
 		focusDirection:         common.EgressFocusDirection,
+		outputFormats:          []string{output.DefaultFormat},
+		supportedOnLiveCluster: true,
+	},
+	{
+		testDirName:            "anp_banp_blog_demo",
+		exposureAnalysis:       true,
+		outputFormats:          []string{output.DefaultFormat},
+		supportedOnLiveCluster: true,
+	},
+	{
+		testDirName:            "anp_banp_blog_demo",
+		focusWorkloads:         []string{"mybar"},
+		focusDirection:         common.EgressFocusDirection,
+		exposureAnalysis:       true,
 		outputFormats:          []string{output.DefaultFormat},
 		supportedOnLiveCluster: true,
 	},

--- a/pkg/netpol/connlist/explanation_test.go
+++ b/pkg/netpol/connlist/explanation_test.go
@@ -76,6 +76,11 @@ var explainTests = []struct {
 	},
 	{
 		testDirName:            "anp_banp_blog_demo",
+		exposure:               true,
+		supportedOnLiveCluster: true,
+	},
+	{
+		testDirName:            "anp_banp_blog_demo",
 		focusWorkloads:         []string{"myfoo"},
 		focusDirection:         common.IngressFocusDirection,
 		supportedOnLiveCluster: true,
@@ -120,6 +125,11 @@ var explainTests = []struct {
 	},
 	{
 		testDirName:            "onlineboutique",
+		supportedOnLiveCluster: true,
+	},
+	{
+		testDirName:            "onlineboutique",
+		exposure:               true,
 		supportedOnLiveCluster: true,
 	},
 	{

--- a/test_outputs/connlist/anp_banp_blog_demo_explain_exposure_output.txt
+++ b/test_outputs/connlist/anp_banp_blog_demo_explain_exposure_output.txt
@@ -1,0 +1,119 @@
+
+##########################################
+# Specific connections and their reasons #
+##########################################
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between 0.0.0.0-255.255.255.255 => foo/myfoo[Pod]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'foo/allow-monitoring' selects foo/myfoo[Pod], but 0.0.0.0-255.255.255.255 is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between bar/mybar[Pod] => foo/myfoo[Pod]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'foo/allow-monitoring' selects foo/myfoo[Pod], but bar/mybar[Pod] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between baz/mybaz[Pod] => bar/mybar[Pod]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			BaselineAdminNetworkPolicy 'default' denies connections by Ingress rule deny-ingress-from-all-namespaces
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between baz/mybaz[Pod] => foo/myfoo[Pod]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'foo/allow-monitoring' selects foo/myfoo[Pod], but baz/mybaz[Pod] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between foo/myfoo[Pod] => bar/mybar[Pod]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			BaselineAdminNetworkPolicy 'default' denies connections by Ingress rule deny-ingress-from-all-namespaces
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between monitoring/mymonitoring[Pod] => bar/mybar[Pod]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			AdminNetworkPolicy 'pass-monitoring' passes connections by Ingress rule pass-ingress-from-monitoring
+			BaselineAdminNetworkPolicy 'default' denies connections by Ingress rule deny-ingress-from-all-namespaces
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between monitoring/mymonitoring[Pod] => baz/mybaz[Pod]:
+
+Allowed connections:
+	Allowed TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Allowed)
+			AdminNetworkPolicy 'allow-monitoring' allows connections by Ingress rule allow-ingress-from-monitoring
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between monitoring/mymonitoring[Pod] => foo/myfoo[Pod]:
+
+Allowed connections:
+	Allowed TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Allowed)
+			AdminNetworkPolicy 'pass-monitoring' passes connections by Ingress rule pass-ingress-from-monitoring
+			NetworkPolicy 'foo/allow-monitoring' allows connections by Ingress rule #1
+
+
+#########################################################
+# All Connections due to the system default (Allow all) #
+#########################################################
+0.0.0.0-255.255.255.255 => bar/mybar[Pod]
+0.0.0.0-255.255.255.255 => baz/mybaz[Pod]
+0.0.0.0-255.255.255.255 => monitoring/mymonitoring[Pod]
+bar/mybar[Pod] => 0.0.0.0-255.255.255.255
+bar/mybar[Pod] => baz/mybaz[Pod]
+bar/mybar[Pod] => monitoring/mymonitoring[Pod]
+baz/mybaz[Pod] => 0.0.0.0-255.255.255.255
+baz/mybaz[Pod] => monitoring/mymonitoring[Pod]
+foo/myfoo[Pod] => 0.0.0.0-255.255.255.255
+foo/myfoo[Pod] => baz/mybaz[Pod]
+foo/myfoo[Pod] => monitoring/mymonitoring[Pod]
+monitoring/mymonitoring[Pod] => 0.0.0.0-255.255.255.255
+
+Exposure Analysis Result:
+Egress Exposure:
+bar/mybar[Pod]               	=> 	0.0.0.0-255.255.255.255 : All Connections
+bar/mybar[Pod]               	=> 	entire-cluster : All Connections
+baz/mybaz[Pod]               	=> 	0.0.0.0-255.255.255.255 : All Connections
+baz/mybaz[Pod]               	=> 	entire-cluster : All Connections
+foo/myfoo[Pod]               	=> 	0.0.0.0-255.255.255.255 : All Connections
+foo/myfoo[Pod]               	=> 	entire-cluster : All Connections
+monitoring/mymonitoring[Pod] 	=> 	0.0.0.0-255.255.255.255 : All Connections
+monitoring/mymonitoring[Pod] 	=> 	entire-cluster : All Connections
+
+Ingress Exposure:
+bar/mybar[Pod]               	<= 	0.0.0.0-255.255.255.255 : All Connections
+baz/mybaz[Pod]               	<= 	0.0.0.0-255.255.255.255 : All Connections
+baz/mybaz[Pod]               	<= 	entire-cluster : All Connections
+foo/myfoo[Pod]               	<= 	monitoring/[all pods] : All Connections
+monitoring/mymonitoring[Pod] 	<= 	0.0.0.0-255.255.255.255 : All Connections
+monitoring/mymonitoring[Pod] 	<= 	entire-cluster : All Connections
+
+Workloads not protected by network policies:
+bar/mybar[Pod] is not protected on Egress
+baz/mybaz[Pod] is not protected on Egress
+foo/myfoo[Pod] is not protected on Egress
+monitoring/mymonitoring[Pod] is not protected on Egress

--- a/test_outputs/connlist/anp_banp_blog_demo_exposure_output.txt
+++ b/test_outputs/connlist/anp_banp_blog_demo_exposure_output.txt
@@ -1,0 +1,39 @@
+0.0.0.0-255.255.255.255 => bar/mybar[Pod] : All Connections
+0.0.0.0-255.255.255.255 => baz/mybaz[Pod] : All Connections
+0.0.0.0-255.255.255.255 => monitoring/mymonitoring[Pod] : All Connections
+bar/mybar[Pod] => 0.0.0.0-255.255.255.255 : All Connections
+bar/mybar[Pod] => baz/mybaz[Pod] : All Connections
+bar/mybar[Pod] => monitoring/mymonitoring[Pod] : All Connections
+baz/mybaz[Pod] => 0.0.0.0-255.255.255.255 : All Connections
+baz/mybaz[Pod] => monitoring/mymonitoring[Pod] : All Connections
+foo/myfoo[Pod] => 0.0.0.0-255.255.255.255 : All Connections
+foo/myfoo[Pod] => baz/mybaz[Pod] : All Connections
+foo/myfoo[Pod] => monitoring/mymonitoring[Pod] : All Connections
+monitoring/mymonitoring[Pod] => 0.0.0.0-255.255.255.255 : All Connections
+monitoring/mymonitoring[Pod] => baz/mybaz[Pod] : All Connections
+monitoring/mymonitoring[Pod] => foo/myfoo[Pod] : All Connections
+
+Exposure Analysis Result:
+Egress Exposure:
+bar/mybar[Pod]               	=> 	0.0.0.0-255.255.255.255 : All Connections
+bar/mybar[Pod]               	=> 	entire-cluster : All Connections
+baz/mybaz[Pod]               	=> 	0.0.0.0-255.255.255.255 : All Connections
+baz/mybaz[Pod]               	=> 	entire-cluster : All Connections
+foo/myfoo[Pod]               	=> 	0.0.0.0-255.255.255.255 : All Connections
+foo/myfoo[Pod]               	=> 	entire-cluster : All Connections
+monitoring/mymonitoring[Pod] 	=> 	0.0.0.0-255.255.255.255 : All Connections
+monitoring/mymonitoring[Pod] 	=> 	entire-cluster : All Connections
+
+Ingress Exposure:
+bar/mybar[Pod]               	<= 	0.0.0.0-255.255.255.255 : All Connections
+baz/mybaz[Pod]               	<= 	0.0.0.0-255.255.255.255 : All Connections
+baz/mybaz[Pod]               	<= 	entire-cluster : All Connections
+foo/myfoo[Pod]               	<= 	monitoring/[all pods] : All Connections
+monitoring/mymonitoring[Pod] 	<= 	0.0.0.0-255.255.255.255 : All Connections
+monitoring/mymonitoring[Pod] 	<= 	entire-cluster : All Connections
+
+Workloads not protected by network policies:
+bar/mybar[Pod] is not protected on Egress
+baz/mybaz[Pod] is not protected on Egress
+foo/myfoo[Pod] is not protected on Egress
+monitoring/mymonitoring[Pod] is not protected on Egress

--- a/test_outputs/connlist/anp_banp_blog_demo_focus_workload_mybar_egress_exposure_output.txt
+++ b/test_outputs/connlist/anp_banp_blog_demo_focus_workload_mybar_egress_exposure_output.txt
@@ -1,0 +1,11 @@
+bar/mybar[Pod] => 0.0.0.0-255.255.255.255 : All Connections
+bar/mybar[Pod] => baz/mybaz[Pod] : All Connections
+bar/mybar[Pod] => monitoring/mymonitoring[Pod] : All Connections
+
+Exposure Analysis Result:
+Egress Exposure:
+bar/mybar[Pod] 	=> 	0.0.0.0-255.255.255.255 : All Connections
+bar/mybar[Pod] 	=> 	entire-cluster : All Connections
+
+Workloads not protected by network policies:
+bar/mybar[Pod] is not protected on Egress

--- a/test_outputs/connlist/onlineboutique_explain_exposure_output.txt
+++ b/test_outputs/connlist/onlineboutique_explain_exposure_output.txt
@@ -1,0 +1,1628 @@
+
+##########################################
+# Specific connections and their reasons #
+##########################################
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between 0.0.0.0-255.255.255.255 => default/adservice-77d5cd745d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between 0.0.0.0-255.255.255.255 => default/cartservice-74f56fd4b[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between 0.0.0.0-255.255.255.255 => default/checkoutservice-69c8ff664b[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between 0.0.0.0-255.255.255.255 => default/currencyservice-77654bbbdd[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between 0.0.0.0-255.255.255.255 => default/emailservice-54c7c5d9d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between 0.0.0.0-255.255.255.255 => default/frontend-99684f7f8[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between 0.0.0.0-255.255.255.255 => default/loadgenerator-555fbdc87d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between 0.0.0.0-255.255.255.255 => default/paymentservice-bbcbdc6b6[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between 0.0.0.0-255.255.255.255 => default/productcatalogservice-68765d49b6[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between 0.0.0.0-255.255.255.255 => default/recommendationservice-5f8c456796[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between 0.0.0.0-255.255.255.255 => default/shippingservice-5bd985c46d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/adservice-77d5cd745d[ReplicaSet] => 0.0.0.0-255.255.255.255:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Egress rule (no rules defined)
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/adservice-77d5cd745d[ReplicaSet] => default/cartservice-74f56fd4b[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but default/cartservice-74f56fd4b[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but default/adservice-77d5cd745d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/adservice-77d5cd745d[ReplicaSet] => default/checkoutservice-69c8ff664b[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but default/checkoutservice-69c8ff664b[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], but default/adservice-77d5cd745d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/adservice-77d5cd745d[ReplicaSet] => default/currencyservice-77654bbbdd[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but default/currencyservice-77654bbbdd[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but default/adservice-77d5cd745d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/adservice-77d5cd745d[ReplicaSet] => default/emailservice-54c7c5d9d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but default/emailservice-54c7c5d9d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but default/adservice-77d5cd745d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/adservice-77d5cd745d[ReplicaSet] => default/frontend-99684f7f8[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but default/frontend-99684f7f8[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], but default/adservice-77d5cd745d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/adservice-77d5cd745d[ReplicaSet] => default/loadgenerator-555fbdc87d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but default/loadgenerator-555fbdc87d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but default/adservice-77d5cd745d[ReplicaSet] is not selected by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/adservice-77d5cd745d[ReplicaSet] => default/paymentservice-bbcbdc6b6[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but default/paymentservice-bbcbdc6b6[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but default/adservice-77d5cd745d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/adservice-77d5cd745d[ReplicaSet] => default/productcatalogservice-68765d49b6[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but default/productcatalogservice-68765d49b6[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], but default/adservice-77d5cd745d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/adservice-77d5cd745d[ReplicaSet] => default/recommendationservice-5f8c456796[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but default/recommendationservice-5f8c456796[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but default/adservice-77d5cd745d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/adservice-77d5cd745d[ReplicaSet] => default/redis-cart-78746d49dc[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/adservice-77d5cd745d[ReplicaSet] => default/shippingservice-5bd985c46d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but default/shippingservice-5bd985c46d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but default/adservice-77d5cd745d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/cartservice-74f56fd4b[ReplicaSet] => 0.0.0.0-255.255.255.255:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Egress rule (no rules defined)
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/cartservice-74f56fd4b[ReplicaSet] => default/adservice-77d5cd745d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but default/adservice-77d5cd745d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but default/cartservice-74f56fd4b[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/cartservice-74f56fd4b[ReplicaSet] => default/checkoutservice-69c8ff664b[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but default/checkoutservice-69c8ff664b[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], but default/cartservice-74f56fd4b[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/cartservice-74f56fd4b[ReplicaSet] => default/currencyservice-77654bbbdd[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but default/currencyservice-77654bbbdd[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but default/cartservice-74f56fd4b[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/cartservice-74f56fd4b[ReplicaSet] => default/emailservice-54c7c5d9d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but default/emailservice-54c7c5d9d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but default/cartservice-74f56fd4b[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/cartservice-74f56fd4b[ReplicaSet] => default/frontend-99684f7f8[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but default/frontend-99684f7f8[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], but default/cartservice-74f56fd4b[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/cartservice-74f56fd4b[ReplicaSet] => default/loadgenerator-555fbdc87d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but default/loadgenerator-555fbdc87d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but default/cartservice-74f56fd4b[ReplicaSet] is not selected by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/cartservice-74f56fd4b[ReplicaSet] => default/paymentservice-bbcbdc6b6[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but default/paymentservice-bbcbdc6b6[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but default/cartservice-74f56fd4b[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/cartservice-74f56fd4b[ReplicaSet] => default/productcatalogservice-68765d49b6[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but default/productcatalogservice-68765d49b6[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], but default/cartservice-74f56fd4b[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/cartservice-74f56fd4b[ReplicaSet] => default/recommendationservice-5f8c456796[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but default/recommendationservice-5f8c456796[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but default/cartservice-74f56fd4b[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/cartservice-74f56fd4b[ReplicaSet] => default/redis-cart-78746d49dc[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/cartservice-74f56fd4b[ReplicaSet] => default/shippingservice-5bd985c46d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but default/shippingservice-5bd985c46d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but default/cartservice-74f56fd4b[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/checkoutservice-69c8ff664b[ReplicaSet] => 0.0.0.0-255.255.255.255:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Egress rule
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/checkoutservice-69c8ff664b[ReplicaSet] => default/adservice-77d5cd745d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], but default/adservice-77d5cd745d[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but default/checkoutservice-69c8ff664b[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/checkoutservice-69c8ff664b[ReplicaSet] => default/cartservice-74f56fd4b[ReplicaSet]:
+
+Allowed connections:
+	Allowed TCP:[7070] due to the following policies and rules:
+		Egress (Allowed)
+			NetworkPolicy 'default/checkoutservice-netpol' allows connections by Egress rule #1
+		Ingress (Allowed)
+			NetworkPolicy 'default/cartservice-netpol' allows connections by Ingress rule #1
+
+Denied connections:
+	Denied TCP:[1-7069,7071-65535], UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], and Egress rule #1 selects default/cartservice-74f56fd4b[ReplicaSet], but the protocols and ports do not match
+		Ingress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], and Ingress rule #1 selects default/checkoutservice-69c8ff664b[ReplicaSet], but the protocols and ports do not match
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/checkoutservice-69c8ff664b[ReplicaSet] => default/currencyservice-77654bbbdd[ReplicaSet]:
+
+Allowed connections:
+	Allowed TCP:[7000] due to the following policies and rules:
+		Egress (Allowed)
+			NetworkPolicy 'default/checkoutservice-netpol' allows connections by Egress rule #2
+		Ingress (Allowed)
+			NetworkPolicy 'default/currencyservice-netpol' allows connections by Ingress rule #1
+
+Denied connections:
+	Denied TCP:[1-6999,7001-65535], UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], and Egress rule #2 selects default/currencyservice-77654bbbdd[ReplicaSet], but the protocols and ports do not match
+		Ingress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], and Ingress rule #1 selects default/checkoutservice-69c8ff664b[ReplicaSet], but the protocols and ports do not match
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/checkoutservice-69c8ff664b[ReplicaSet] => default/emailservice-54c7c5d9d[ReplicaSet]:
+
+Allowed connections:
+	Allowed TCP:[8080] due to the following policies and rules:
+		Egress (Allowed)
+			NetworkPolicy 'default/checkoutservice-netpol' allows connections by Egress rule #3
+		Ingress (Allowed)
+			NetworkPolicy 'default/emailservice-netpol' allows connections by Ingress rule #1
+
+Denied connections:
+	Denied TCP:[1-8079,8081-65535], UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], and Egress rule #3 selects default/emailservice-54c7c5d9d[ReplicaSet], but the protocols and ports do not match
+		Ingress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], and Ingress rule #1 selects default/checkoutservice-69c8ff664b[ReplicaSet], but the protocols and ports do not match
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/checkoutservice-69c8ff664b[ReplicaSet] => default/frontend-99684f7f8[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], but default/frontend-99684f7f8[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], but default/checkoutservice-69c8ff664b[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/checkoutservice-69c8ff664b[ReplicaSet] => default/loadgenerator-555fbdc87d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], but default/loadgenerator-555fbdc87d[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but default/checkoutservice-69c8ff664b[ReplicaSet] is not selected by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/checkoutservice-69c8ff664b[ReplicaSet] => default/paymentservice-bbcbdc6b6[ReplicaSet]:
+
+Allowed connections:
+	Allowed TCP:[50051] due to the following policies and rules:
+		Egress (Allowed)
+			NetworkPolicy 'default/checkoutservice-netpol' allows connections by Egress rule #4
+		Ingress (Allowed)
+			NetworkPolicy 'default/paymentservice-netpol' allows connections by Ingress rule #1
+
+Denied connections:
+	Denied TCP:[1-50050,50052-65535], UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], and Egress rule #4 selects default/paymentservice-bbcbdc6b6[ReplicaSet], but the protocols and ports do not match
+		Ingress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], and Ingress rule #1 selects default/checkoutservice-69c8ff664b[ReplicaSet], but the protocols and ports do not match
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/checkoutservice-69c8ff664b[ReplicaSet] => default/productcatalogservice-68765d49b6[ReplicaSet]:
+
+Allowed connections:
+	Allowed TCP:[3550] due to the following policies and rules:
+		Egress (Allowed)
+			NetworkPolicy 'default/checkoutservice-netpol' allows connections by Egress rule #5
+		Ingress (Allowed)
+			NetworkPolicy 'default/productcatalogservice-netpol' allows connections by Ingress rule #1
+
+Denied connections:
+	Denied TCP:[1-3549,3551-65535], UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], and Egress rule #5 selects default/productcatalogservice-68765d49b6[ReplicaSet], but the protocols and ports do not match
+		Ingress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], and Ingress rule #1 selects default/checkoutservice-69c8ff664b[ReplicaSet], but the protocols and ports do not match
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/checkoutservice-69c8ff664b[ReplicaSet] => default/recommendationservice-5f8c456796[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], but default/recommendationservice-5f8c456796[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but default/checkoutservice-69c8ff664b[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/checkoutservice-69c8ff664b[ReplicaSet] => default/redis-cart-78746d49dc[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Egress rule
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/checkoutservice-69c8ff664b[ReplicaSet] => default/shippingservice-5bd985c46d[ReplicaSet]:
+
+Allowed connections:
+	Allowed TCP:[50051] due to the following policies and rules:
+		Egress (Allowed)
+			NetworkPolicy 'default/checkoutservice-netpol' allows connections by Egress rule #6
+		Ingress (Allowed)
+			NetworkPolicy 'default/shippingservice-netpol' allows connections by Ingress rule #1
+
+Denied connections:
+	Denied TCP:[1-50050,50052-65535], UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], and Egress rule #6 selects default/shippingservice-5bd985c46d[ReplicaSet], but the protocols and ports do not match
+		Ingress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], and Ingress rule #1 selects default/checkoutservice-69c8ff664b[ReplicaSet], but the protocols and ports do not match
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/currencyservice-77654bbbdd[ReplicaSet] => 0.0.0.0-255.255.255.255:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Egress rule (no rules defined)
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/currencyservice-77654bbbdd[ReplicaSet] => default/adservice-77d5cd745d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but default/adservice-77d5cd745d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but default/currencyservice-77654bbbdd[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/currencyservice-77654bbbdd[ReplicaSet] => default/cartservice-74f56fd4b[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but default/cartservice-74f56fd4b[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but default/currencyservice-77654bbbdd[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/currencyservice-77654bbbdd[ReplicaSet] => default/checkoutservice-69c8ff664b[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but default/checkoutservice-69c8ff664b[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], but default/currencyservice-77654bbbdd[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/currencyservice-77654bbbdd[ReplicaSet] => default/emailservice-54c7c5d9d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but default/emailservice-54c7c5d9d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but default/currencyservice-77654bbbdd[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/currencyservice-77654bbbdd[ReplicaSet] => default/frontend-99684f7f8[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but default/frontend-99684f7f8[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], but default/currencyservice-77654bbbdd[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/currencyservice-77654bbbdd[ReplicaSet] => default/loadgenerator-555fbdc87d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but default/loadgenerator-555fbdc87d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but default/currencyservice-77654bbbdd[ReplicaSet] is not selected by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/currencyservice-77654bbbdd[ReplicaSet] => default/paymentservice-bbcbdc6b6[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but default/paymentservice-bbcbdc6b6[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but default/currencyservice-77654bbbdd[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/currencyservice-77654bbbdd[ReplicaSet] => default/productcatalogservice-68765d49b6[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but default/productcatalogservice-68765d49b6[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], but default/currencyservice-77654bbbdd[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/currencyservice-77654bbbdd[ReplicaSet] => default/recommendationservice-5f8c456796[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but default/recommendationservice-5f8c456796[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but default/currencyservice-77654bbbdd[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/currencyservice-77654bbbdd[ReplicaSet] => default/redis-cart-78746d49dc[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/currencyservice-77654bbbdd[ReplicaSet] => default/shippingservice-5bd985c46d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but default/shippingservice-5bd985c46d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but default/currencyservice-77654bbbdd[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/emailservice-54c7c5d9d[ReplicaSet] => 0.0.0.0-255.255.255.255:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Egress rule (no rules defined)
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/emailservice-54c7c5d9d[ReplicaSet] => default/adservice-77d5cd745d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but default/adservice-77d5cd745d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but default/emailservice-54c7c5d9d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/emailservice-54c7c5d9d[ReplicaSet] => default/cartservice-74f56fd4b[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but default/cartservice-74f56fd4b[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but default/emailservice-54c7c5d9d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/emailservice-54c7c5d9d[ReplicaSet] => default/checkoutservice-69c8ff664b[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but default/checkoutservice-69c8ff664b[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], but default/emailservice-54c7c5d9d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/emailservice-54c7c5d9d[ReplicaSet] => default/currencyservice-77654bbbdd[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but default/currencyservice-77654bbbdd[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but default/emailservice-54c7c5d9d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/emailservice-54c7c5d9d[ReplicaSet] => default/frontend-99684f7f8[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but default/frontend-99684f7f8[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], but default/emailservice-54c7c5d9d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/emailservice-54c7c5d9d[ReplicaSet] => default/loadgenerator-555fbdc87d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but default/loadgenerator-555fbdc87d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but default/emailservice-54c7c5d9d[ReplicaSet] is not selected by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/emailservice-54c7c5d9d[ReplicaSet] => default/paymentservice-bbcbdc6b6[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but default/paymentservice-bbcbdc6b6[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but default/emailservice-54c7c5d9d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/emailservice-54c7c5d9d[ReplicaSet] => default/productcatalogservice-68765d49b6[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but default/productcatalogservice-68765d49b6[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], but default/emailservice-54c7c5d9d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/emailservice-54c7c5d9d[ReplicaSet] => default/recommendationservice-5f8c456796[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but default/recommendationservice-5f8c456796[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but default/emailservice-54c7c5d9d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/emailservice-54c7c5d9d[ReplicaSet] => default/redis-cart-78746d49dc[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/emailservice-54c7c5d9d[ReplicaSet] => default/shippingservice-5bd985c46d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but default/shippingservice-5bd985c46d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but default/emailservice-54c7c5d9d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/frontend-99684f7f8[ReplicaSet] => 0.0.0.0-255.255.255.255:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Egress rule
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/frontend-99684f7f8[ReplicaSet] => default/adservice-77d5cd745d[ReplicaSet]:
+
+Allowed connections:
+	Allowed TCP:[9555] due to the following policies and rules:
+		Egress (Allowed)
+			NetworkPolicy 'default/frontend-netpol' allows connections by Egress rule #1
+		Ingress (Allowed)
+			NetworkPolicy 'default/adservice-netpol' allows connections by Ingress rule #1
+
+Denied connections:
+	Denied TCP:[1-9554,9556-65535], UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], and Egress rule #1 selects default/adservice-77d5cd745d[ReplicaSet], but the protocols and ports do not match
+		Ingress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], and Ingress rule #1 selects default/frontend-99684f7f8[ReplicaSet], but the protocols and ports do not match
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/frontend-99684f7f8[ReplicaSet] => default/cartservice-74f56fd4b[ReplicaSet]:
+
+Allowed connections:
+	Allowed TCP:[7070] due to the following policies and rules:
+		Egress (Allowed)
+			NetworkPolicy 'default/frontend-netpol' allows connections by Egress rule #2
+		Ingress (Allowed)
+			NetworkPolicy 'default/cartservice-netpol' allows connections by Ingress rule #2
+
+Denied connections:
+	Denied TCP:[1-7069,7071-65535], UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], and Egress rule #2 selects default/cartservice-74f56fd4b[ReplicaSet], but the protocols and ports do not match
+		Ingress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], and Ingress rule #2 selects default/frontend-99684f7f8[ReplicaSet], but the protocols and ports do not match
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/frontend-99684f7f8[ReplicaSet] => default/checkoutservice-69c8ff664b[ReplicaSet]:
+
+Allowed connections:
+	Allowed TCP:[5050] due to the following policies and rules:
+		Egress (Allowed)
+			NetworkPolicy 'default/frontend-netpol' allows connections by Egress rule #3
+		Ingress (Allowed)
+			NetworkPolicy 'default/checkoutservice-netpol' allows connections by Ingress rule #1
+
+Denied connections:
+	Denied TCP:[1-5049,5051-65535], UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], and Egress rule #3 selects default/checkoutservice-69c8ff664b[ReplicaSet], but the protocols and ports do not match
+		Ingress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], and Ingress rule #1 selects default/frontend-99684f7f8[ReplicaSet], but the protocols and ports do not match
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/frontend-99684f7f8[ReplicaSet] => default/currencyservice-77654bbbdd[ReplicaSet]:
+
+Allowed connections:
+	Allowed TCP:[7000] due to the following policies and rules:
+		Egress (Allowed)
+			NetworkPolicy 'default/frontend-netpol' allows connections by Egress rule #4
+		Ingress (Allowed)
+			NetworkPolicy 'default/currencyservice-netpol' allows connections by Ingress rule #2
+
+Denied connections:
+	Denied TCP:[1-6999,7001-65535], UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], and Egress rule #4 selects default/currencyservice-77654bbbdd[ReplicaSet], but the protocols and ports do not match
+		Ingress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], and Ingress rule #2 selects default/frontend-99684f7f8[ReplicaSet], but the protocols and ports do not match
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/frontend-99684f7f8[ReplicaSet] => default/emailservice-54c7c5d9d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], but default/emailservice-54c7c5d9d[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but default/frontend-99684f7f8[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/frontend-99684f7f8[ReplicaSet] => default/loadgenerator-555fbdc87d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], but default/loadgenerator-555fbdc87d[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but default/frontend-99684f7f8[ReplicaSet] is not selected by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/frontend-99684f7f8[ReplicaSet] => default/paymentservice-bbcbdc6b6[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], but default/paymentservice-bbcbdc6b6[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but default/frontend-99684f7f8[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/frontend-99684f7f8[ReplicaSet] => default/productcatalogservice-68765d49b6[ReplicaSet]:
+
+Allowed connections:
+	Allowed TCP:[3550] due to the following policies and rules:
+		Egress (Allowed)
+			NetworkPolicy 'default/frontend-netpol' allows connections by Egress rule #5
+		Ingress (Allowed)
+			NetworkPolicy 'default/productcatalogservice-netpol' allows connections by Ingress rule #2
+
+Denied connections:
+	Denied TCP:[1-3549,3551-65535], UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], and Egress rule #5 selects default/productcatalogservice-68765d49b6[ReplicaSet], but the protocols and ports do not match
+		Ingress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], and Ingress rule #2 selects default/frontend-99684f7f8[ReplicaSet], but the protocols and ports do not match
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/frontend-99684f7f8[ReplicaSet] => default/recommendationservice-5f8c456796[ReplicaSet]:
+
+Allowed connections:
+	Allowed TCP:[8080] due to the following policies and rules:
+		Egress (Allowed)
+			NetworkPolicy 'default/frontend-netpol' allows connections by Egress rule #6
+		Ingress (Allowed)
+			NetworkPolicy 'default/recommendationservice-netpol' allows connections by Ingress rule #1
+
+Denied connections:
+	Denied TCP:[1-8079,8081-65535], UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], and Egress rule #6 selects default/recommendationservice-5f8c456796[ReplicaSet], but the protocols and ports do not match
+		Ingress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], and Ingress rule #1 selects default/frontend-99684f7f8[ReplicaSet], but the protocols and ports do not match
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/frontend-99684f7f8[ReplicaSet] => default/redis-cart-78746d49dc[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Egress rule
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/frontend-99684f7f8[ReplicaSet] => default/shippingservice-5bd985c46d[ReplicaSet]:
+
+Allowed connections:
+	Allowed TCP:[50051] due to the following policies and rules:
+		Egress (Allowed)
+			NetworkPolicy 'default/frontend-netpol' allows connections by Egress rule #7
+		Ingress (Allowed)
+			NetworkPolicy 'default/shippingservice-netpol' allows connections by Ingress rule #2
+
+Denied connections:
+	Denied TCP:[1-50050,50052-65535], UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], and Egress rule #7 selects default/shippingservice-5bd985c46d[ReplicaSet], but the protocols and ports do not match
+		Ingress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], and Ingress rule #2 selects default/frontend-99684f7f8[ReplicaSet], but the protocols and ports do not match
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/loadgenerator-555fbdc87d[ReplicaSet] => 0.0.0.0-255.255.255.255:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Egress rule
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/loadgenerator-555fbdc87d[ReplicaSet] => default/adservice-77d5cd745d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but default/adservice-77d5cd745d[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but default/loadgenerator-555fbdc87d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/loadgenerator-555fbdc87d[ReplicaSet] => default/cartservice-74f56fd4b[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but default/cartservice-74f56fd4b[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but default/loadgenerator-555fbdc87d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/loadgenerator-555fbdc87d[ReplicaSet] => default/checkoutservice-69c8ff664b[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but default/checkoutservice-69c8ff664b[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], but default/loadgenerator-555fbdc87d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/loadgenerator-555fbdc87d[ReplicaSet] => default/currencyservice-77654bbbdd[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but default/currencyservice-77654bbbdd[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but default/loadgenerator-555fbdc87d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/loadgenerator-555fbdc87d[ReplicaSet] => default/emailservice-54c7c5d9d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but default/emailservice-54c7c5d9d[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but default/loadgenerator-555fbdc87d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/loadgenerator-555fbdc87d[ReplicaSet] => default/frontend-99684f7f8[ReplicaSet]:
+
+Allowed connections:
+	Allowed TCP:[8080] due to the following policies and rules:
+		Egress (Allowed)
+			NetworkPolicy 'default/loadgenerator-netpol' allows connections by Egress rule #1
+		Ingress (Allowed)
+			NetworkPolicy 'default/frontend-netpol' allows connections by Ingress rule #1
+
+Denied connections:
+	Denied TCP:[1-8079,8081-65535], UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], and Egress rule #1 selects default/frontend-99684f7f8[ReplicaSet], but the protocols and ports do not match
+		Ingress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], and Ingress rule #1 selects default/loadgenerator-555fbdc87d[ReplicaSet], but the protocols and ports do not match
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/loadgenerator-555fbdc87d[ReplicaSet] => default/paymentservice-bbcbdc6b6[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but default/paymentservice-bbcbdc6b6[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but default/loadgenerator-555fbdc87d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/loadgenerator-555fbdc87d[ReplicaSet] => default/productcatalogservice-68765d49b6[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but default/productcatalogservice-68765d49b6[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], but default/loadgenerator-555fbdc87d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/loadgenerator-555fbdc87d[ReplicaSet] => default/recommendationservice-5f8c456796[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but default/recommendationservice-5f8c456796[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but default/loadgenerator-555fbdc87d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/loadgenerator-555fbdc87d[ReplicaSet] => default/redis-cart-78746d49dc[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Egress rule
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/loadgenerator-555fbdc87d[ReplicaSet] => default/shippingservice-5bd985c46d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but default/shippingservice-5bd985c46d[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but default/loadgenerator-555fbdc87d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/paymentservice-bbcbdc6b6[ReplicaSet] => 0.0.0.0-255.255.255.255:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Egress rule (no rules defined)
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/paymentservice-bbcbdc6b6[ReplicaSet] => default/adservice-77d5cd745d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but default/adservice-77d5cd745d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but default/paymentservice-bbcbdc6b6[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/paymentservice-bbcbdc6b6[ReplicaSet] => default/cartservice-74f56fd4b[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but default/cartservice-74f56fd4b[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but default/paymentservice-bbcbdc6b6[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/paymentservice-bbcbdc6b6[ReplicaSet] => default/checkoutservice-69c8ff664b[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but default/checkoutservice-69c8ff664b[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], but default/paymentservice-bbcbdc6b6[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/paymentservice-bbcbdc6b6[ReplicaSet] => default/currencyservice-77654bbbdd[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but default/currencyservice-77654bbbdd[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but default/paymentservice-bbcbdc6b6[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/paymentservice-bbcbdc6b6[ReplicaSet] => default/emailservice-54c7c5d9d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but default/emailservice-54c7c5d9d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but default/paymentservice-bbcbdc6b6[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/paymentservice-bbcbdc6b6[ReplicaSet] => default/frontend-99684f7f8[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but default/frontend-99684f7f8[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], but default/paymentservice-bbcbdc6b6[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/paymentservice-bbcbdc6b6[ReplicaSet] => default/loadgenerator-555fbdc87d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but default/loadgenerator-555fbdc87d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but default/paymentservice-bbcbdc6b6[ReplicaSet] is not selected by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/paymentservice-bbcbdc6b6[ReplicaSet] => default/productcatalogservice-68765d49b6[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but default/productcatalogservice-68765d49b6[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], but default/paymentservice-bbcbdc6b6[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/paymentservice-bbcbdc6b6[ReplicaSet] => default/recommendationservice-5f8c456796[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but default/recommendationservice-5f8c456796[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but default/paymentservice-bbcbdc6b6[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/paymentservice-bbcbdc6b6[ReplicaSet] => default/redis-cart-78746d49dc[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/paymentservice-bbcbdc6b6[ReplicaSet] => default/shippingservice-5bd985c46d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but default/shippingservice-5bd985c46d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but default/paymentservice-bbcbdc6b6[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/productcatalogservice-68765d49b6[ReplicaSet] => 0.0.0.0-255.255.255.255:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Egress rule (no rules defined)
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/productcatalogservice-68765d49b6[ReplicaSet] => default/adservice-77d5cd745d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], but default/adservice-77d5cd745d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but default/productcatalogservice-68765d49b6[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/productcatalogservice-68765d49b6[ReplicaSet] => default/cartservice-74f56fd4b[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], but default/cartservice-74f56fd4b[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but default/productcatalogservice-68765d49b6[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/productcatalogservice-68765d49b6[ReplicaSet] => default/checkoutservice-69c8ff664b[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], but default/checkoutservice-69c8ff664b[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], but default/productcatalogservice-68765d49b6[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/productcatalogservice-68765d49b6[ReplicaSet] => default/currencyservice-77654bbbdd[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], but default/currencyservice-77654bbbdd[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but default/productcatalogservice-68765d49b6[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/productcatalogservice-68765d49b6[ReplicaSet] => default/emailservice-54c7c5d9d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], but default/emailservice-54c7c5d9d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but default/productcatalogservice-68765d49b6[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/productcatalogservice-68765d49b6[ReplicaSet] => default/frontend-99684f7f8[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], but default/frontend-99684f7f8[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], but default/productcatalogservice-68765d49b6[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/productcatalogservice-68765d49b6[ReplicaSet] => default/loadgenerator-555fbdc87d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], but default/loadgenerator-555fbdc87d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but default/productcatalogservice-68765d49b6[ReplicaSet] is not selected by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/productcatalogservice-68765d49b6[ReplicaSet] => default/paymentservice-bbcbdc6b6[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], but default/paymentservice-bbcbdc6b6[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but default/productcatalogservice-68765d49b6[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/productcatalogservice-68765d49b6[ReplicaSet] => default/recommendationservice-5f8c456796[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], but default/recommendationservice-5f8c456796[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but default/productcatalogservice-68765d49b6[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/productcatalogservice-68765d49b6[ReplicaSet] => default/redis-cart-78746d49dc[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/productcatalogservice-68765d49b6[ReplicaSet] => default/shippingservice-5bd985c46d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], but default/shippingservice-5bd985c46d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but default/productcatalogservice-68765d49b6[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/recommendationservice-5f8c456796[ReplicaSet] => 0.0.0.0-255.255.255.255:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Egress rule
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/recommendationservice-5f8c456796[ReplicaSet] => default/adservice-77d5cd745d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but default/adservice-77d5cd745d[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but default/recommendationservice-5f8c456796[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/recommendationservice-5f8c456796[ReplicaSet] => default/cartservice-74f56fd4b[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but default/cartservice-74f56fd4b[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but default/recommendationservice-5f8c456796[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/recommendationservice-5f8c456796[ReplicaSet] => default/checkoutservice-69c8ff664b[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but default/checkoutservice-69c8ff664b[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], but default/recommendationservice-5f8c456796[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/recommendationservice-5f8c456796[ReplicaSet] => default/currencyservice-77654bbbdd[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but default/currencyservice-77654bbbdd[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but default/recommendationservice-5f8c456796[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/recommendationservice-5f8c456796[ReplicaSet] => default/emailservice-54c7c5d9d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but default/emailservice-54c7c5d9d[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but default/recommendationservice-5f8c456796[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/recommendationservice-5f8c456796[ReplicaSet] => default/frontend-99684f7f8[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but default/frontend-99684f7f8[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], but default/recommendationservice-5f8c456796[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/recommendationservice-5f8c456796[ReplicaSet] => default/loadgenerator-555fbdc87d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but default/loadgenerator-555fbdc87d[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but default/recommendationservice-5f8c456796[ReplicaSet] is not selected by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/recommendationservice-5f8c456796[ReplicaSet] => default/paymentservice-bbcbdc6b6[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but default/paymentservice-bbcbdc6b6[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but default/recommendationservice-5f8c456796[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/recommendationservice-5f8c456796[ReplicaSet] => default/productcatalogservice-68765d49b6[ReplicaSet]:
+
+Allowed connections:
+	Allowed TCP:[3550] due to the following policies and rules:
+		Egress (Allowed)
+			NetworkPolicy 'default/recommendationservice-netpol' allows connections by Egress rule #1
+		Ingress (Allowed)
+			NetworkPolicy 'default/productcatalogservice-netpol' allows connections by Ingress rule #3
+
+Denied connections:
+	Denied TCP:[1-3549,3551-65535], UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], and Egress rule #1 selects default/productcatalogservice-68765d49b6[ReplicaSet], but the protocols and ports do not match
+		Ingress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], and Ingress rule #3 selects default/recommendationservice-5f8c456796[ReplicaSet], but the protocols and ports do not match
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/recommendationservice-5f8c456796[ReplicaSet] => default/redis-cart-78746d49dc[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Egress rule
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/recommendationservice-5f8c456796[ReplicaSet] => default/shippingservice-5bd985c46d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but default/shippingservice-5bd985c46d[ReplicaSet] is not selected by any Egress rule
+		Ingress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but default/recommendationservice-5f8c456796[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/redis-cart-78746d49dc[ReplicaSet] => default/adservice-77d5cd745d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/redis-cart-78746d49dc[ReplicaSet] => default/cartservice-74f56fd4b[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/redis-cart-78746d49dc[ReplicaSet] => default/checkoutservice-69c8ff664b[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/redis-cart-78746d49dc[ReplicaSet] => default/currencyservice-77654bbbdd[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/redis-cart-78746d49dc[ReplicaSet] => default/emailservice-54c7c5d9d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/redis-cart-78746d49dc[ReplicaSet] => default/frontend-99684f7f8[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/redis-cart-78746d49dc[ReplicaSet] => default/loadgenerator-555fbdc87d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/redis-cart-78746d49dc[ReplicaSet] => default/paymentservice-bbcbdc6b6[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/redis-cart-78746d49dc[ReplicaSet] => default/productcatalogservice-68765d49b6[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/redis-cart-78746d49dc[ReplicaSet] => default/recommendationservice-5f8c456796[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/redis-cart-78746d49dc[ReplicaSet] => default/shippingservice-5bd985c46d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/shippingservice-5bd985c46d[ReplicaSet] => 0.0.0.0-255.255.255.255:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but 0.0.0.0-255.255.255.255 is not selected by any Egress rule (no rules defined)
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/shippingservice-5bd985c46d[ReplicaSet] => default/adservice-77d5cd745d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but default/adservice-77d5cd745d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/adservice-netpol' selects default/adservice-77d5cd745d[ReplicaSet], but default/shippingservice-5bd985c46d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/shippingservice-5bd985c46d[ReplicaSet] => default/cartservice-74f56fd4b[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but default/cartservice-74f56fd4b[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/cartservice-netpol' selects default/cartservice-74f56fd4b[ReplicaSet], but default/shippingservice-5bd985c46d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/shippingservice-5bd985c46d[ReplicaSet] => default/checkoutservice-69c8ff664b[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but default/checkoutservice-69c8ff664b[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/checkoutservice-netpol' selects default/checkoutservice-69c8ff664b[ReplicaSet], but default/shippingservice-5bd985c46d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/shippingservice-5bd985c46d[ReplicaSet] => default/currencyservice-77654bbbdd[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but default/currencyservice-77654bbbdd[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/currencyservice-netpol' selects default/currencyservice-77654bbbdd[ReplicaSet], but default/shippingservice-5bd985c46d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/shippingservice-5bd985c46d[ReplicaSet] => default/emailservice-54c7c5d9d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but default/emailservice-54c7c5d9d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/emailservice-netpol' selects default/emailservice-54c7c5d9d[ReplicaSet], but default/shippingservice-5bd985c46d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/shippingservice-5bd985c46d[ReplicaSet] => default/frontend-99684f7f8[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but default/frontend-99684f7f8[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/frontend-netpol' selects default/frontend-99684f7f8[ReplicaSet], but default/shippingservice-5bd985c46d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/shippingservice-5bd985c46d[ReplicaSet] => default/loadgenerator-555fbdc87d[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but default/loadgenerator-555fbdc87d[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/loadgenerator-netpol' selects default/loadgenerator-555fbdc87d[ReplicaSet], but default/shippingservice-5bd985c46d[ReplicaSet] is not selected by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/shippingservice-5bd985c46d[ReplicaSet] => default/paymentservice-bbcbdc6b6[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but default/paymentservice-bbcbdc6b6[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/paymentservice-netpol' selects default/paymentservice-bbcbdc6b6[ReplicaSet], but default/shippingservice-5bd985c46d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/shippingservice-5bd985c46d[ReplicaSet] => default/productcatalogservice-68765d49b6[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but default/productcatalogservice-68765d49b6[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/productcatalogservice-netpol' selects default/productcatalogservice-68765d49b6[ReplicaSet], but default/shippingservice-5bd985c46d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/shippingservice-5bd985c46d[ReplicaSet] => default/recommendationservice-5f8c456796[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but default/recommendationservice-5f8c456796[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'default/recommendationservice-netpol' selects default/recommendationservice-5f8c456796[ReplicaSet], but default/shippingservice-5bd985c46d[ReplicaSet] is not selected by any Ingress rule
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between default/shippingservice-5bd985c46d[ReplicaSet] => default/redis-cart-78746d49dc[ReplicaSet]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'default/shippingservice-netpol' selects default/shippingservice-5bd985c46d[ReplicaSet], but default/redis-cart-78746d49dc[ReplicaSet] is not selected by any Egress rule (no rules defined)
+		Ingress (Allowed) due to the system default (Allow all)
+
+
+#########################################################
+# All Connections due to the system default (Allow all) #
+#########################################################
+0.0.0.0-255.255.255.255 => default/redis-cart-78746d49dc[ReplicaSet]
+default/redis-cart-78746d49dc[ReplicaSet] => 0.0.0.0-255.255.255.255
+
+Exposure Analysis Result:
+Egress Exposure:
+default/checkoutservice-69c8ff664b[ReplicaSet]       	=> 	[all namespaces]/[pod with {k8s-app=kube-dns}] : UDP 53
+default/frontend-99684f7f8[ReplicaSet]               	=> 	[all namespaces]/[pod with {k8s-app=kube-dns}] : UDP 53
+default/loadgenerator-555fbdc87d[ReplicaSet]         	=> 	[all namespaces]/[pod with {k8s-app=kube-dns}] : UDP 53
+default/recommendationservice-5f8c456796[ReplicaSet] 	=> 	[all namespaces]/[pod with {k8s-app=kube-dns}] : UDP 53
+default/redis-cart-78746d49dc[ReplicaSet]            	=> 	0.0.0.0-255.255.255.255 : All Connections
+default/redis-cart-78746d49dc[ReplicaSet]            	=> 	entire-cluster : All Connections
+
+Ingress Exposure:
+default/redis-cart-78746d49dc[ReplicaSet]            	<= 	0.0.0.0-255.255.255.255 : All Connections
+default/redis-cart-78746d49dc[ReplicaSet]            	<= 	entire-cluster : All Connections
+
+Workloads not protected by network policies:
+default/redis-cart-78746d49dc[ReplicaSet] is not protected on Egress
+default/redis-cart-78746d49dc[ReplicaSet] is not protected on Ingress

--- a/test_outputs/connlist/onlineboutique_exposure_output.md
+++ b/test_outputs/connlist/onlineboutique_exposure_output.md
@@ -1,0 +1,35 @@
+| src | dst | conn |
+|-----|-----|------|
+| 0.0.0.0-255.255.255.255 | default/redis-cart-78746d49dc[ReplicaSet] | All Connections |
+| default/checkoutservice-69c8ff664b[ReplicaSet] | default/cartservice-74f56fd4b[ReplicaSet] | TCP 7070 |
+| default/checkoutservice-69c8ff664b[ReplicaSet] | default/currencyservice-77654bbbdd[ReplicaSet] | TCP 7000 |
+| default/checkoutservice-69c8ff664b[ReplicaSet] | default/emailservice-54c7c5d9d[ReplicaSet] | TCP 8080 |
+| default/checkoutservice-69c8ff664b[ReplicaSet] | default/paymentservice-bbcbdc6b6[ReplicaSet] | TCP 50051 |
+| default/checkoutservice-69c8ff664b[ReplicaSet] | default/productcatalogservice-68765d49b6[ReplicaSet] | TCP 3550 |
+| default/checkoutservice-69c8ff664b[ReplicaSet] | default/shippingservice-5bd985c46d[ReplicaSet] | TCP 50051 |
+| default/frontend-99684f7f8[ReplicaSet] | default/adservice-77d5cd745d[ReplicaSet] | TCP 9555 |
+| default/frontend-99684f7f8[ReplicaSet] | default/cartservice-74f56fd4b[ReplicaSet] | TCP 7070 |
+| default/frontend-99684f7f8[ReplicaSet] | default/checkoutservice-69c8ff664b[ReplicaSet] | TCP 5050 |
+| default/frontend-99684f7f8[ReplicaSet] | default/currencyservice-77654bbbdd[ReplicaSet] | TCP 7000 |
+| default/frontend-99684f7f8[ReplicaSet] | default/productcatalogservice-68765d49b6[ReplicaSet] | TCP 3550 |
+| default/frontend-99684f7f8[ReplicaSet] | default/recommendationservice-5f8c456796[ReplicaSet] | TCP 8080 |
+| default/frontend-99684f7f8[ReplicaSet] | default/shippingservice-5bd985c46d[ReplicaSet] | TCP 50051 |
+| default/loadgenerator-555fbdc87d[ReplicaSet] | default/frontend-99684f7f8[ReplicaSet] | TCP 8080 |
+| default/recommendationservice-5f8c456796[ReplicaSet] | default/productcatalogservice-68765d49b6[ReplicaSet] | TCP 3550 |
+| default/redis-cart-78746d49dc[ReplicaSet] | 0.0.0.0-255.255.255.255 | All Connections |
+## Exposure Analysis Result:
+### Egress Exposure:
+| src | dst | conn |
+|-----|-----|------|
+| default/checkoutservice-69c8ff664b[ReplicaSet] | [all namespaces]/[pod with {k8s-app=kube-dns}] | UDP 53 |
+| default/frontend-99684f7f8[ReplicaSet] | [all namespaces]/[pod with {k8s-app=kube-dns}] | UDP 53 |
+| default/loadgenerator-555fbdc87d[ReplicaSet] | [all namespaces]/[pod with {k8s-app=kube-dns}] | UDP 53 |
+| default/recommendationservice-5f8c456796[ReplicaSet] | [all namespaces]/[pod with {k8s-app=kube-dns}] | UDP 53 |
+| default/redis-cart-78746d49dc[ReplicaSet] | 0.0.0.0-255.255.255.255 | All Connections |
+| default/redis-cart-78746d49dc[ReplicaSet] | entire-cluster | All Connections |
+
+### Ingress Exposure:
+| dst | src | conn |
+|-----|-----|------|
+| default/redis-cart-78746d49dc[ReplicaSet] | 0.0.0.0-255.255.255.255 | All Connections |
+| default/redis-cart-78746d49dc[ReplicaSet] | entire-cluster | All Connections |

--- a/test_outputs/connlist/onlineboutique_exposure_output.txt
+++ b/test_outputs/connlist/onlineboutique_exposure_output.txt
@@ -1,0 +1,34 @@
+0.0.0.0-255.255.255.255 => default/redis-cart-78746d49dc[ReplicaSet] : All Connections
+default/checkoutservice-69c8ff664b[ReplicaSet] => default/cartservice-74f56fd4b[ReplicaSet] : TCP 7070
+default/checkoutservice-69c8ff664b[ReplicaSet] => default/currencyservice-77654bbbdd[ReplicaSet] : TCP 7000
+default/checkoutservice-69c8ff664b[ReplicaSet] => default/emailservice-54c7c5d9d[ReplicaSet] : TCP 8080
+default/checkoutservice-69c8ff664b[ReplicaSet] => default/paymentservice-bbcbdc6b6[ReplicaSet] : TCP 50051
+default/checkoutservice-69c8ff664b[ReplicaSet] => default/productcatalogservice-68765d49b6[ReplicaSet] : TCP 3550
+default/checkoutservice-69c8ff664b[ReplicaSet] => default/shippingservice-5bd985c46d[ReplicaSet] : TCP 50051
+default/frontend-99684f7f8[ReplicaSet] => default/adservice-77d5cd745d[ReplicaSet] : TCP 9555
+default/frontend-99684f7f8[ReplicaSet] => default/cartservice-74f56fd4b[ReplicaSet] : TCP 7070
+default/frontend-99684f7f8[ReplicaSet] => default/checkoutservice-69c8ff664b[ReplicaSet] : TCP 5050
+default/frontend-99684f7f8[ReplicaSet] => default/currencyservice-77654bbbdd[ReplicaSet] : TCP 7000
+default/frontend-99684f7f8[ReplicaSet] => default/productcatalogservice-68765d49b6[ReplicaSet] : TCP 3550
+default/frontend-99684f7f8[ReplicaSet] => default/recommendationservice-5f8c456796[ReplicaSet] : TCP 8080
+default/frontend-99684f7f8[ReplicaSet] => default/shippingservice-5bd985c46d[ReplicaSet] : TCP 50051
+default/loadgenerator-555fbdc87d[ReplicaSet] => default/frontend-99684f7f8[ReplicaSet] : TCP 8080
+default/recommendationservice-5f8c456796[ReplicaSet] => default/productcatalogservice-68765d49b6[ReplicaSet] : TCP 3550
+default/redis-cart-78746d49dc[ReplicaSet] => 0.0.0.0-255.255.255.255 : All Connections
+
+Exposure Analysis Result:
+Egress Exposure:
+default/checkoutservice-69c8ff664b[ReplicaSet]       	=> 	[all namespaces]/[pod with {k8s-app=kube-dns}] : UDP 53
+default/frontend-99684f7f8[ReplicaSet]               	=> 	[all namespaces]/[pod with {k8s-app=kube-dns}] : UDP 53
+default/loadgenerator-555fbdc87d[ReplicaSet]         	=> 	[all namespaces]/[pod with {k8s-app=kube-dns}] : UDP 53
+default/recommendationservice-5f8c456796[ReplicaSet] 	=> 	[all namespaces]/[pod with {k8s-app=kube-dns}] : UDP 53
+default/redis-cart-78746d49dc[ReplicaSet]            	=> 	0.0.0.0-255.255.255.255 : All Connections
+default/redis-cart-78746d49dc[ReplicaSet]            	=> 	entire-cluster : All Connections
+
+Ingress Exposure:
+default/redis-cart-78746d49dc[ReplicaSet]            	<= 	0.0.0.0-255.255.255.255 : All Connections
+default/redis-cart-78746d49dc[ReplicaSet]            	<= 	entire-cluster : All Connections
+
+Workloads not protected by network policies:
+default/redis-cart-78746d49dc[ReplicaSet] is not protected on Egress
+default/redis-cart-78746d49dc[ReplicaSet] is not protected on Ingress


### PR DESCRIPTION
#539 

- supporting exposure analysis on live cluster (by adding k8s live-cluster objects to policy-engine in the order required for exposure-analysis)

- added tests that run successfully on mock-server

- tested also on live-cluster 