### PR TITLE
Issue 480: cases to enable connectivity analysis even when there is a labels-gap between pods of same owner-reference

### DIFF
--- a/pkg/netpol/connlist/connlist_test.go
+++ b/pkg/netpol/connlist/connlist_test.go
@@ -2003,6 +2003,24 @@ var goodPathTests = []struct {
 		outputFormats:          []string{output.DefaultFormat},
 		supportedOnLiveCluster: true,
 	},
+	{
+		// in following example we have 2 pods which belong to same owner;
+		// the pods have different labels;
+		// however, since there are no policies in the input resources
+		// a connectivity report is generated (the labels diff does not affect the analysis)
+		testDirName:            "example_pods_w_same_owner_and_labels_gap_no_policy",
+		outputFormats:          []string{output.DefaultFormat},
+		supportedOnLiveCluster: true,
+	},
+	{
+		// in following example we have 2 pods which belong to same owner; the pods have different labels;
+		// however, since the policy rule selector (which selects those pods) uses a label-selector which is same in both pods
+		// i.e. not from the gap:
+		// a connectivity report is generated (the labels diff does not affect the analysis)
+		testDirName:            "example_pods_w_same_owner_and_labels_gap_with_policy_selector_not_in_gap",
+		outputFormats:          []string{output.DefaultFormat},
+		supportedOnLiveCluster: true,
+	},
 }
 
 func runParsedResourcesConnlistTests(t *testing.T, testList []examples.ParsedResourcesTest) {

--- a/pkg/netpol/connlist/connlist_test.go
+++ b/pkg/netpol/connlist/connlist_test.go
@@ -171,9 +171,19 @@ func TestConnlistAnalyzeFatalErrors(t *testing.T) {
 		},*/
 		// pods list issue - pods with same owner but different labels
 		{
-			name:             "Input_dir_has_illegal_podlist_pods_with_same_owner_ref_name_has_different_labels_should_return_fatal_error",
+			name:             "Input_dir_has_pods_with_same_owner_name_w_different_labels_selected_by_policy_should_return_fatal_error",
 			dirName:          "semanticDiff-same-topologies-illegal-podlist",
 			errorStrContains: alerts.NotSupportedPodResourcesErrorStr("demo/cog-agents"),
+		},
+		{
+			name:             "Input_dir_has_pods_with_same_owner_name_w_different_labels_selected_by_policy_should_return_fatal_error2",
+			dirName:          "example_pods_w_same_owner_and_labels_gap_with_bad_match_expression",
+			errorStrContains: alerts.NotSupportedPodResourcesErrorStr("default/internal-security"),
+		},
+		{
+			name:             "Input_dir_has_pods_with_same_owner_name_w_different_labels_selected_by_policy_should_return_fatal_error3",
+			dirName:          "example_w_err_pods_w_same_owner_and_labels_gap_anp",
+			errorStrContains: alerts.NotSupportedPodResourcesErrorStr("default/internal-security"),
 		},
 		{
 			name:             "Input_dir_has_two_netpols_with_same_name_in_a_namespace_should_return_fatal_error_of_existing_object",
@@ -2018,6 +2028,40 @@ var goodPathTests = []struct {
 		// i.e. not from the gap:
 		// a connectivity report is generated (the labels diff does not affect the analysis)
 		testDirName:            "example_pods_w_same_owner_and_labels_gap_with_policy_selector_not_in_gap",
+		outputFormats:          []string{output.DefaultFormat},
+		supportedOnLiveCluster: true,
+	},
+	{
+		// in following example we have 2 pods which belong to same owner; the pods have different labels;
+		// however, since the admin-policy subject (which selects those pods) uses a label-selector which is same in both pods
+		// i.e. not from the gap:
+		// a connectivity report is generated (the labels diff does not affect the analysis)
+		testDirName:            "example_pods_w_same_owner_and_labels_gap_anp_good",
+		outputFormats:          []string{output.DefaultFormat},
+		supportedOnLiveCluster: true,
+	},
+	{
+		// in following example we have 2 pods which belong to same owner; the pods have different labels;
+		// however, since the policy (which selects those pods) uses a matchExpression with exists opertaor (no matter what the value is)
+		// a connectivity report is generated (the labels diff does not affect the analysis)
+		testDirName:            "example_pods_w_same_owner_and_labels_gap_with_good_match_expression",
+		outputFormats:          []string{output.DefaultFormat},
+		supportedOnLiveCluster: true,
+	},
+	{
+		// in following example we have 2 pods which belong to same owner; the pods have different labels;
+		// however, since the baseline-admin-policy (which selects those pods) uses a label-selector which is same in both pods
+		// a connectivity report is generated (the labels diff does not affect the analysis)
+		testDirName:            "example_pods_w_same_owner_and_labels_gap_banp_good",
+		outputFormats:          []string{output.DefaultFormat},
+		supportedOnLiveCluster: true,
+	},
+	{
+		// in following example we have 2 pods which belong to same owner; the pods have different labels;
+		// however, since the policy (which selects those pods) uses a matchExpression with in opertaor
+		// and both gap-values
+		// a connectivity report is generated (the labels diff does not affect the analysis)
+		testDirName:            "example_pods_w_same_owner_and_labels_gap_with_good_match_expression2",
 		outputFormats:          []string{output.DefaultFormat},
 		supportedOnLiveCluster: true,
 	},

--- a/pkg/netpol/eval/internal/k8s/adminnetpol.go
+++ b/pkg/netpol/eval/internal/k8s/adminnetpol.go
@@ -865,3 +865,102 @@ func updateAdminNetworkPolicyExposureClusterWideConns(rulePorts *[]apisv1a.Admin
 	return xgressPolicyClusterWideExposure.UpdateWithRuleConns(ruleConns, ruleAction, false)
 	// note that : the last parameter sent to UpdateWithRuleConns is false, since the pre-process func assumes rules are legal
 }
+
+//////////////////////////////////////////////// ////////////////////////////////////////////////
+// funcs to check if any policy-selector selects a label from the gap of two pods referencing same owner.
+
+// ContainsLabels given input map from key to values list (each key has 2 values);
+// returns first captured key from the map that the policy selectors (Subject or ruleSelectors) uses with at least one of those values
+//
+// i.e. returns non-empty key if:
+// - there is a labelSelector with matchLabels: {<key>: <val_in_gap>} (contains a key:val from the input map)
+// - there is a selector with matchExpression with values list (operator not Exist/ DoesNotExist) that contains only one of the gap-values
+//
+//nolint:dupl // AdminNetworkPolicy and BaselineAdminNetworkPolicy are not same object - this func will be removed on enhancement
+func (anp *AdminNetworkPolicy) ContainsLabels(ownerNs *Namespace, diffLabels map[string][]string) (key, selectorStr string) {
+	// first check the policy's Subject
+	// if the subject contains only namespaces field; i.e it selects all pods in the namespace	- no problem
+	if anp.Spec.Subject.Namespaces == nil && anp.Spec.Subject.Pods != nil {
+		if key, selectorStr := podsFieldContainsDiffLabel(anp.Spec.Subject.Pods, ownerNs, diffLabels); key != "" {
+			return key, selectorStr
+		}
+	}
+
+	//  loop egress rules selectors
+	if anp.adminPolicyAffectsDirection(false) {
+		if key, egressSel := anp.egressRulesContainGapLabel(ownerNs, diffLabels); key != "" {
+			return key, egressSel
+		}
+	}
+	// loop ingress rules selectors
+	if anp.adminPolicyAffectsDirection(true) {
+		if key, ingressSel := anp.ingressRulesContainGapLabel(ownerNs, diffLabels); key != "" {
+			return key, ingressSel
+		}
+	}
+	return "", ""
+}
+
+func (anp *AdminNetworkPolicy) egressRulesContainGapLabel(ownerNs *Namespace, diffLabels map[string][]string) (key, selector string) {
+	for _, rule := range anp.Spec.Egress {
+		rulePeers := rule.To
+		if key, selector = egressRulePeerContainsGapLabel(rulePeers, ownerNs, diffLabels); key != "" {
+			return key, selector
+		}
+	}
+	return "", ""
+}
+
+func (anp *AdminNetworkPolicy) ingressRulesContainGapLabel(ownerNs *Namespace, diffLabels map[string][]string) (key, selector string) {
+	for _, rule := range anp.Spec.Ingress {
+		rulePeers := rule.From
+		if key, selector = ingressRulePeerContainsGapLabel(rulePeers, ownerNs, diffLabels); key != "" {
+			return key, selector
+		}
+	}
+	return "", ""
+}
+
+func podsFieldContainsDiffLabel(podsField *apisv1a.NamespacedPod, ownerNs *Namespace, diffLabels map[string][]string) (key,
+	selector string) {
+	// check first the namespaceSelector
+	nsSelector, _ := metav1.LabelSelectorAsSelector(&podsField.NamespaceSelector) // assuming correctness,
+	if !nsSelector.Matches(labels.Set(ownerNs.Labels)) {                          // ns selector does not select the owner's ns
+		return "", ""
+	}
+	// ns selector matches owner namespace, check if podSelector contains gap labels
+	if key := selectorContainsGapLabel(&podsField.PodSelector, diffLabels); key != "" {
+		return key, podsField.PodSelector.String()
+	}
+	return "", ""
+}
+
+func egressRulePeerContainsGapLabel(rulePeers []apisv1a.AdminNetworkPolicyEgressPeer, ownerNs *Namespace,
+	diffLabels map[string][]string) (key, selector string) {
+	for _, rule := range rulePeers {
+		// if rule contains namespaces - continue : no problem
+		if rule.Namespaces != nil {
+			continue
+		}
+		// pods field is used - check if matches ownerNs and contains pod-selectors from the gap
+		if key, selector := podsFieldContainsDiffLabel(rule.Pods, ownerNs, diffLabels); key != "" {
+			return key, selector
+		}
+	}
+	return "", ""
+}
+
+func ingressRulePeerContainsGapLabel(rulePeers []apisv1a.AdminNetworkPolicyIngressPeer, ownerNs *Namespace,
+	diffLabels map[string][]string) (key, selector string) {
+	for _, rule := range rulePeers {
+		// if rule contains namespaces - continue : no problems
+		if rule.Namespaces != nil {
+			continue
+		}
+		// pods field is used - check if matches ownerNs and contains pod-selectors from the gap
+		if key, selector := podsFieldContainsDiffLabel(rule.Pods, ownerNs, diffLabels); key != "" {
+			return key, selector
+		}
+	}
+	return "", ""
+}

--- a/pkg/netpol/eval/internal/k8s/adminnetpol.go
+++ b/pkg/netpol/eval/internal/k8s/adminnetpol.go
@@ -929,8 +929,8 @@ func podsFieldContainsDiffLabel(podsField *apisv1a.NamespacedPod, ownerNs *Names
 		return "", ""
 	}
 	// ns selector matches owner namespace, check if podSelector contains gap labels
-	if key := selectorContainsGapLabel(&podsField.PodSelector, diffLabels); key != "" {
-		return key, podsField.PodSelector.String()
+	if key, selectorStr := selectorContainsGapLabel(&podsField.PodSelector, diffLabels); key != "" {
+		return key, selectorStr
 	}
 	return "", ""
 }

--- a/pkg/netpol/eval/internal/k8s/netpol.go
+++ b/pkg/netpol/eval/internal/k8s/netpol.go
@@ -585,6 +585,118 @@ func (np *NetworkPolicy) LogWarnings(l logger.Logger) {
 	np.warnings.LogPolicyWarnings(l)
 }
 
+//////////////////////////////////////////////// ////////////////////////////////////////////////
+// funcs to check if any policy-selector selects a label from the gap of two pods referencing same owner.
+
+// ContainsLabels given input map from key to values list (each key has 2 values);
+// returns first captured key from the map that the policy selectors (PodSelector or ruleSelectors) uses with at least one of those values
+//
+// i.e. returns non-empty key if:
+// - there is a labelSelector with matchLabels: {<key>: <val_in_gap>} (contains a key:val from the input map)
+// - there is a selector with matchExpression with values list (operator not Exist/ DoesNotExist) that contains only one of the gap-values
+func (np *NetworkPolicy) ContainsLabels(ownerNs *Namespace, diffLabels map[string][]string) (key, selectorStr string) {
+	//  if the policy is in the owner's Ns: first check the policy's Spec.PodSelector
+	if np.Namespace == ownerNs.Name {
+		if key := selectorContainsGapLabel(&np.Spec.PodSelector, diffLabels); key != "" {
+			return key, np.Spec.PodSelector.String()
+		}
+	}
+
+	//  loop egress rules selectors
+	if np.policyAffectsDirection(netv1.PolicyTypeEgress) {
+		if key, egressSel := np.egressRulesContainGapLabel(ownerNs, diffLabels); key != "" {
+			return key, egressSel
+		}
+	}
+	// loop ingress rules selectors
+	if np.policyAffectsDirection(netv1.PolicyTypeIngress) {
+		if key, ingressSel := np.ingressRulesContainGapLabel(ownerNs, diffLabels); key != "" {
+			return key, ingressSel
+		}
+	}
+	return "", ""
+}
+
+func selectorContainsGapLabel(selector *metav1.LabelSelector, diffLabels map[string][]string) string {
+	if len(selector.MatchLabels) > 0 {
+		for key := range diffLabels {
+			if _, ok := selector.MatchLabels[key]; ok {
+				// a label key from the gap is used in the policy - return to raise an error if one value is from the list
+				if selector.MatchLabels[key] == diffLabels[key][0] || selector.MatchLabels[key] == diffLabels[key][1] {
+					return key
+				}
+			}
+		}
+	}
+	if len(selector.MatchExpressions) > 0 {
+		// using a key from a gap is ok only if the operator is Exist or DoesNotExist;
+		// otherwise the values of the key may match only some of the owner's pods values and
+		//  then the connectivity results may be ambiguous
+		for i := range selector.MatchExpressions {
+			if selector.MatchExpressions[i].Operator == metav1.LabelSelectorOpExists ||
+				selector.MatchExpressions[i].Operator == metav1.LabelSelectorOpDoesNotExist {
+				continue
+			} // else the matchExpression has values list, if it contains any of the values in the gap-list return the key
+			if _, ok := diffLabels[selector.MatchExpressions[i].Key]; ok {
+				exprValuesStr := strings.Join(selector.MatchExpressions[i].Values, ",")
+				containsFirstVal := strings.Contains(exprValuesStr, diffLabels[selector.MatchExpressions[i].Key][0])
+				containsSecondVal := strings.Contains(exprValuesStr, diffLabels[selector.MatchExpressions[i].Key][1])
+				// enable analysis if values list contain both gap-vals
+				if containsFirstVal && containsSecondVal {
+					continue
+				}
+				// disable if contains only one
+				if containsFirstVal || containsSecondVal {
+					return selector.MatchExpressions[i].Key
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func (np *NetworkPolicy) egressRulesContainGapLabel(ownerNs *Namespace, diffLabels map[string][]string) (key, selector string) {
+	for _, rule := range np.Spec.Egress {
+		rulePeers := rule.To
+		if key, selector = xgressRulePeerContainsGapLabel(rulePeers, ownerNs, diffLabels); key != "" {
+			return key, selector
+		}
+	}
+	return "", ""
+}
+
+func (np *NetworkPolicy) ingressRulesContainGapLabel(ownerNs *Namespace, diffLabels map[string][]string) (key, selector string) {
+	for _, rule := range np.Spec.Ingress {
+		rulePeers := rule.From
+		if key, selector = xgressRulePeerContainsGapLabel(rulePeers, ownerNs, diffLabels); key != "" {
+			return key, selector
+		}
+	}
+	return "", ""
+}
+
+func xgressRulePeerContainsGapLabel(rules []netv1.NetworkPolicyPeer, ownerNs *Namespace,
+	diffLabels map[string][]string) (key, selector string) {
+	if len(rules) == 0 {
+		return "", ""
+	}
+	for i := range rules {
+		if rules[i].IPBlock != nil {
+			continue
+		}
+		nsSelector, _ := metav1.LabelSelectorAsSelector(rules[i].NamespaceSelector) // assuming correctness,
+		if rules[i].NamespaceSelector != nil && !nsSelector.Matches(labels.Set(ownerNs.Labels)) {
+			// ns selector does not select the owner's ns
+			continue
+		}
+		// ns selector matches owner namespace, check if podSelector contains gap labels
+		if key := selectorContainsGapLabel(rules[i].PodSelector, diffLabels); key != "" {
+			return key, rules[i].PodSelector.String()
+		}
+	}
+	return "", ""
+}
+
 // /////////////////////////////////////////////////////////////////////////////////////////////
 // pre-processing computations - currently performed for exposure-analysis goals only;
 // all pre-process funcs assume policies' rules are legal (rules correctness check occurs later)

--- a/pkg/netpol/eval/internal/k8s/pod.go
+++ b/pkg/netpol/eval/internal/k8s/pod.go
@@ -128,7 +128,7 @@ func PodFromCoreObject(p *corev1.Pod) (*Pod, error) {
 
 	for refIndex := range p.ObjectMeta.OwnerReferences {
 		ownerRef := p.ObjectMeta.OwnerReferences[refIndex]
-		if *ownerRef.Controller {
+		if ownerRef.Controller != nil && *ownerRef.Controller {
 			if addOwner := addPodOwner(&ownerRef, pr); addOwner {
 				pr.Owner.Variant = variantFromLabelsMap(p.Labels)
 			}

--- a/pkg/netpol/eval/resources.go
+++ b/pkg/netpol/eval/resources.go
@@ -506,9 +506,9 @@ func generateLabelsDiffError(firstPod, newPod *k8s.Pod, gapData *labelsDiffData)
 	firstPodStr := types.NamespacedName{Namespace: firstPod.Namespace, Name: firstPod.Name}.String()
 	errMsgPart1 := alerts.NotSupportedPodResourcesErrorStr(ownerName)
 	errMsgPart2 := ""
-	keyMissingErr := " Pod %s has label %s=%s, and Pod %s does not have label %s."
-	differentValuesErr := " Pod %s has label %s=%s, and Pod %s has label %s=%s."
-	policyValuesErr := fmt.Sprintf(" While %s contains selector %s", gapData.policyStr, gapData.policySelectorStr)
+	keyMissingErr := "Pod %q has label `%s=%s`, and Pod %q does not have label `%s`."
+	differentValuesErr := "Pod %q has label `%s=%s`, and Pod %q has label `%s=%s`."
+	policyValuesErr := fmt.Sprintf(" While %s contains selector `%s`", gapData.policyStr, gapData.policySelectorStr)
 	switch {
 	case gapData.firstVal == "":
 		errMsgPart2 = fmt.Sprintf(keyMissingErr, newPodStr, gapData.key, gapData.secondVal, firstPodStr, gapData.key)
@@ -564,7 +564,7 @@ func (pe *PolicyEngine) checkIfDifferentLabelsUsedByPolicy(ownerNs string,
 		for _, np := range pe.netpolsMap[ns] {
 			if key, selectorStr := np.ContainsLabels(pe.namespacesMap[ownerNs], differentLabels); key != "" {
 				return &labelsDiffData{key: key, firstVal: differentLabels[key][0], secondVal: differentLabels[key][1],
-					policyStr:         "NetworkPolicy: " + types.NamespacedName{Name: np.Name, Namespace: np.Namespace}.String(),
+					policyStr:         fmt.Sprintf("NetworkPolicy: %q", types.NamespacedName{Name: np.Name, Namespace: np.Namespace}.String()),
 					policySelectorStr: selectorStr}
 			}
 		}
@@ -573,7 +573,7 @@ func (pe *PolicyEngine) checkIfDifferentLabelsUsedByPolicy(ownerNs string,
 	for _, anp := range pe.sortedAdminNetpols {
 		if key, selectorStr := anp.ContainsLabels(pe.namespacesMap[ownerNs], differentLabels); key != "" {
 			return &labelsDiffData{key: key, firstVal: differentLabels[key][0], secondVal: differentLabels[key][1],
-				policyStr:         "AdminNetworkPolicy: " + anp.Name,
+				policyStr:         fmt.Sprintf("AdminNetworkPolicy: %q", anp.Name),
 				policySelectorStr: selectorStr}
 		}
 	}
@@ -581,7 +581,7 @@ func (pe *PolicyEngine) checkIfDifferentLabelsUsedByPolicy(ownerNs string,
 	if pe.baselineAdminNetpol != nil {
 		if key, selectorStr := pe.baselineAdminNetpol.ContainsLabels(pe.namespacesMap[ownerNs], differentLabels); key != "" {
 			return &labelsDiffData{key: key, firstVal: differentLabels[key][0], secondVal: differentLabels[key][1],
-				policyStr:         "BaselineAdminNetworkPolicy: " + pe.baselineAdminNetpol.Name,
+				policyStr:         fmt.Sprintf("BaselineAdminNetworkPolicy: %q", pe.baselineAdminNetpol.Name),
 				policySelectorStr: selectorStr}
 		}
 	}

--- a/pkg/netpol/eval/resources.go
+++ b/pkg/netpol/eval/resources.go
@@ -506,9 +506,9 @@ func generateLabelsDiffError(firstPod, newPod *k8s.Pod, gapData *labelsDiffData)
 	firstPodStr := types.NamespacedName{Namespace: firstPod.Namespace, Name: firstPod.Name}.String()
 	errMsgPart1 := alerts.NotSupportedPodResourcesErrorStr(ownerName)
 	errMsgPart2 := ""
-	keyMissingErr := "Pod %q has label `%s=%s`, and Pod %q does not have label `%s`."
-	differentValuesErr := "Pod %q has label `%s=%s`, and Pod %q has label `%s=%s`."
-	policyValuesErr := fmt.Sprintf(" While %s contains selector `%s`", gapData.policyStr, gapData.policySelectorStr)
+	keyMissingErr := "Pod %q has label `%s=%s`, and Pod %q does not have label `%s`,"
+	differentValuesErr := "Pod %q has label `%s=%s`, and Pod %q has label `%s=%s`,"
+	policyValuesErr := fmt.Sprintf(" while %s contains selector `%s`", gapData.policyStr, gapData.policySelectorStr)
 	switch {
 	case gapData.firstVal == "":
 		errMsgPart2 = fmt.Sprintf(keyMissingErr, newPodStr, gapData.key, gapData.secondVal, firstPodStr, gapData.key)

--- a/pkg/netpol/eval/resources.go
+++ b/pkg/netpol/eval/resources.go
@@ -453,7 +453,9 @@ func (pe *PolicyEngine) insertNamespace(ns *corev1.Namespace) error {
 	return nil
 }
 
-// checkConsistentLabelsForPodsOfSameOwner returns error if there are pod resources with same ownerReferences name but different labels
+// checkConsistentLabelsForPodsOfSameOwner returns error if:
+// there are pod resources with same ownerReferences name but different labels (labels gap) and there is a policy selector or
+// policy-rule selector which selects the pods with a label from the gap
 func (pe *PolicyEngine) checkConsistentLabelsForPodsOfSameOwner(newPod *k8s.Pod) error {
 	if newPod.Owner.Name == "" { // the new pod does not have owner references
 		return nil
@@ -466,15 +468,38 @@ func (pe *PolicyEngine) checkConsistentLabelsForPodsOfSameOwner(newPod *k8s.Pod)
 		pe.podOwnersToRepresentativePodMap[newPod.Namespace][newPod.Owner.Name] = newPod
 		return nil
 	}
-	// compare the owner first pod's labels with new pod's Labels
-	if key, firstVal, newVal := diffBetweenPodsLabels(firstPod, newPod); key != "" {
-		return generateLabelsDiffError(firstPod, newPod, key, firstVal, newVal) // err
+
+	// if there are no policies in the policy-engine then labels diffs do not affect connectivity results - return
+	if !pe.hasPolicies() {
+		return nil
+	}
+	// @todo: as enhancement may compare selectors with gap-labels on the flow of computing the allowed-conns,
+	// then generating the error would be moved
+
+	// compare the owner first pod's labels with new pod's Labels;
+	// if there is a diff between labels which may affect the connectivity results (labels from the gap used by policies);
+	// then return an error with first captured different label's values
+	if gapData := pe.diffBetweenPodsLabelsAffectConnectivity(firstPod, newPod); gapData.key != "" {
+		return generateLabelsDiffError(firstPod, newPod, gapData) // err
 	}
 	return nil
 }
 
+func (pe *PolicyEngine) hasPolicies() bool {
+	return len(pe.netpolsMap) > 0 || len(pe.sortedAdminNetpols) > 0 || pe.baselineAdminNetpol != nil
+}
+
+// labelsDiffData contains data of the first captured label from the gap-labels which is selected by a policy
+type labelsDiffData struct {
+	key               string
+	firstVal          string
+	secondVal         string
+	policyStr         string
+	policySelectorStr string
+}
+
 // helper: generateLabelsDiffError generates the error message of the gap between two pods' labels
-func generateLabelsDiffError(firstPod, newPod *k8s.Pod, key, firstVal, newVal string) error {
+func generateLabelsDiffError(firstPod, newPod *k8s.Pod, gapData *labelsDiffData) error {
 	// helping vars declarations to avoid duplicates
 	ownerName := types.NamespacedName{Namespace: firstPod.Namespace, Name: firstPod.Owner.Name}.String()
 	newPodStr := types.NamespacedName{Namespace: newPod.Namespace, Name: newPod.Name}.String()
@@ -483,37 +508,84 @@ func generateLabelsDiffError(firstPod, newPod *k8s.Pod, key, firstVal, newVal st
 	errMsgPart2 := ""
 	keyMissingErr := " Pod %s has label %s=%s, and Pod %s does not have label %s."
 	differentValuesErr := " Pod %s has label %s=%s, and Pod %s has label %s=%s."
+	policyValuesErr := fmt.Sprintf(" While %s contains selector %s", gapData.policyStr, gapData.policySelectorStr)
 	switch {
-	case firstVal == "":
-		errMsgPart2 = fmt.Sprintf(keyMissingErr, newPodStr, key, newVal, firstPodStr, key)
-	case newVal == "":
-		errMsgPart2 = fmt.Sprintf(keyMissingErr, firstPodStr, key, firstVal, newPodStr, key)
+	case gapData.firstVal == "":
+		errMsgPart2 = fmt.Sprintf(keyMissingErr, newPodStr, gapData.key, gapData.secondVal, firstPodStr, gapData.key)
+	case gapData.secondVal == "":
+		errMsgPart2 = fmt.Sprintf(keyMissingErr, firstPodStr, gapData.key, gapData.firstVal, newPodStr, gapData.key)
 	default: // both values are not empty
-		errMsgPart2 = fmt.Sprintf(differentValuesErr, newPodStr, key, newVal, firstPodStr, key, firstVal)
+		errMsgPart2 = fmt.Sprintf(differentValuesErr, newPodStr, gapData.key, gapData.secondVal, firstPodStr, gapData.key, gapData.firstVal)
 	}
-	return errors.New(errMsgPart1 + errMsgPart2)
+	return errors.New(errMsgPart1 + errMsgPart2 + policyValuesErr)
 }
 
 // helper: given two pods of same owner, if there are diffs between the pods' labels maps returns first captured diff components,
-// i.e. the different label's key and the different values / empty val if the key is missing in one pod's labels;
-// if there is no diff, returns empty key (with empty values)
-func diffBetweenPodsLabels(firstPod, newPod *k8s.Pod) (key, firstVal, newVal string) {
+// i.e. the different label's key and the different values / empty val if the key is missing in one pod's labels
+// with the strings of policy and selector which uses that label;
+// if there is no diff/ diff labels are not selected by any policy-selector, returns empty key (with empty values)
+func (pe *PolicyEngine) diffBetweenPodsLabelsAffectConnectivity(firstPod, newPod *k8s.Pod) (gapData *labelsDiffData) {
 	// try to find diffs by looping new pod's labels first
+	differentLabels := map[string][]string{} // map from key to its values in the two pods
 	for key, value := range newPod.Labels {
-		if _, ok := firstPod.Labels[key]; !ok {
-			return key, "", value
+		if _, ok := firstPod.Labels[key]; !ok { // newPod has a key which does not exist in the firstPod
+			differentLabels[key] = []string{"", value}
 		}
-		if firstPod.Labels[key] != value {
-			return key, firstPod.Labels[key], value
+		if firstPod.Labels[key] != value { // the values of the label key are not equal
+			differentLabels[key] = []string{firstPod.Labels[key], value}
 		}
 	}
 	// check if first pod's labels contains keys which are not in the new pod's labels
 	for key, val := range firstPod.Labels {
 		if _, ok := newPod.Labels[key]; !ok {
-			return key, val, ""
+			differentLabels[key] = []string{val, ""}
 		}
 	}
-	return "", "", ""
+	// following func is called only in case there are policies in the policy engine and there is a pod-owner with pods with labels gap
+	// however, it is possible to implement this in another way,
+	// @todo - in order to enhance performance; instead of checking if the policies use the different labels here, add "differentLabels" map
+	// (with more data on the owner and pods) as a policy-engine attribute.
+	// and while looping policies for computing allowed conns between peers, do this check (pass the pe.differentLabels to those funcs)
+	if len(differentLabels) > 0 {
+		return pe.checkIfDifferentLabelsUsedByPolicy(firstPod.Namespace, differentLabels)
+	}
+	return &labelsDiffData{}
+}
+
+// checkIfDifferentLabelsUsedByPolicy loops the policies and checks if any of the policies' selectors contains
+// a key label from the input differentLabels map
+// if a policy selector contains such <key:val> label or a match expression that may cause an ambiguity on selecting the
+// correct pods (where the pods has same owner but labels with same key and different values)
+// the connectivity analysis is not supported for input resources.
+func (pe *PolicyEngine) checkIfDifferentLabelsUsedByPolicy(ownerNs string,
+	differentLabels map[string][]string) (gapData *labelsDiffData) {
+	// check if different labels are selected by the policies and may affect the analysis results
+	for ns := range pe.netpolsMap {
+		for _, np := range pe.netpolsMap[ns] {
+			if key, selectorStr := np.ContainsLabels(pe.namespacesMap[ownerNs], differentLabels); key != "" {
+				return &labelsDiffData{key: key, firstVal: differentLabels[key][0], secondVal: differentLabels[key][1],
+					policyStr:         "NetworkPolicy: " + types.NamespacedName{Name: np.Name, Namespace: np.Namespace}.String(),
+					policySelectorStr: selectorStr}
+			}
+		}
+	}
+	// check on admin-netpols
+	for _, anp := range pe.sortedAdminNetpols {
+		if key, selectorStr := anp.ContainsLabels(pe.namespacesMap[ownerNs], differentLabels); key != "" {
+			return &labelsDiffData{key: key, firstVal: differentLabels[key][0], secondVal: differentLabels[key][1],
+				policyStr:         "AdminNetworkPolicy: " + anp.Name,
+				policySelectorStr: selectorStr}
+		}
+	}
+	// check the baselineAdminNetpol
+	if pe.baselineAdminNetpol != nil {
+		if key, selectorStr := pe.baselineAdminNetpol.ContainsLabels(pe.namespacesMap[ownerNs], differentLabels); key != "" {
+			return &labelsDiffData{key: key, firstVal: differentLabels[key][0], secondVal: differentLabels[key][1],
+				policyStr:         "BaselineAdminNetworkPolicy: " + pe.baselineAdminNetpol.Name,
+				policySelectorStr: selectorStr}
+		}
+	}
+	return &labelsDiffData{}
 }
 
 func (pe *PolicyEngine) insertWorkload(rs interface{}, kind string) error {

--- a/pkg/netpol/internal/alerts/errors.go
+++ b/pkg/netpol/internal/alerts/errors.go
@@ -64,8 +64,8 @@ func IllegalPortRangeError(start, end int64) string {
 // NotSupportedPodResourcesErrorStr returns error string of not supported pods with same ownerRef but different labels
 // which are selected by a policy
 func NotSupportedPodResourcesErrorStr(ownerRefName string) string {
-	return "Input resources are not supported for connectivity analysis. Found Pods of the same owner " +
-		ownerRefName + " but with different set of labels. And found a policy containing selectors from the different labels set."
+	return "Found Pods of the same owner workload `" + ownerRefName +
+		"` and with differences in their labels, while a network policy contains selectors impacted by this gap.\n"
 }
 
 // InvalidPeerErrStr returns error string of an invalid peer

--- a/pkg/netpol/internal/alerts/errors.go
+++ b/pkg/netpol/internal/alerts/errors.go
@@ -62,9 +62,10 @@ func IllegalPortRangeError(start, end int64) string {
 // eval pkg errors:
 
 // NotSupportedPodResourcesErrorStr returns error string of not supported pods with same ownerRef but different labels
+// which are selected by a policy
 func NotSupportedPodResourcesErrorStr(ownerRefName string) string {
-	return "Input Pod resources are not supported for connectivity analysis. Found Pods of the same owner " +
-		ownerRefName + " but with different set of labels."
+	return "Input resources are not supported for connectivity analysis. Found Pods of the same owner " +
+		ownerRefName + " but with different set of labels. And found a policy containing selectors from the different labels set."
 }
 
 // InvalidPeerErrStr returns error string of an invalid peer

--- a/test_outputs/connlist/example_pods_w_same_owner_and_labels_gap_anp_good_connlist_output.txt
+++ b/test_outputs/connlist/example_pods_w_same_owner_and_labels_gap_anp_good_connlist_output.txt
@@ -1,0 +1,6 @@
+0.0.0.0-255.255.255.255 => default/internal-security[Pod] : All Connections
+0.0.0.0-255.255.255.255 => default/pod-3[Pod] : All Connections
+default/internal-security[Pod] => 0.0.0.0-255.255.255.255 : All Connections
+default/internal-security[Pod] => default/pod-3[Pod] : All Connections
+default/pod-3[Pod] => 0.0.0.0-255.255.255.255 : All Connections
+default/pod-3[Pod] => default/internal-security[Pod] : TCP 80

--- a/test_outputs/connlist/example_pods_w_same_owner_and_labels_gap_banp_good_connlist_output.txt
+++ b/test_outputs/connlist/example_pods_w_same_owner_and_labels_gap_banp_good_connlist_output.txt
@@ -1,0 +1,5 @@
+0.0.0.0-255.255.255.255 => default/internal-security[Pod] : All Connections
+0.0.0.0-255.255.255.255 => default/pod-3[Pod] : All Connections
+default/internal-security[Pod] => 0.0.0.0-255.255.255.255 : All Connections
+default/internal-security[Pod] => default/pod-3[Pod] : All Connections
+default/pod-3[Pod] => 0.0.0.0-255.255.255.255 : All Connections

--- a/test_outputs/connlist/example_pods_w_same_owner_and_labels_gap_no_policy_connlist_output.txt
+++ b/test_outputs/connlist/example_pods_w_same_owner_and_labels_gap_no_policy_connlist_output.txt
@@ -1,0 +1,2 @@
+0.0.0.0-255.255.255.255 => default/internal-security[Pod] : All Connections
+default/internal-security[Pod] => 0.0.0.0-255.255.255.255 : All Connections

--- a/test_outputs/connlist/example_pods_w_same_owner_and_labels_gap_with_good_match_expression2_connlist_output.txt
+++ b/test_outputs/connlist/example_pods_w_same_owner_and_labels_gap_with_good_match_expression2_connlist_output.txt
@@ -1,0 +1,3 @@
+default/internal-security[Pod] => 0.0.0.0-255.255.255.255 : All Connections
+default/internal-security[Pod] => default/pod-3[Pod] : TCP 90
+default/pod-3[Pod] => 0.0.0.0-255.255.255.255 : All Connections

--- a/test_outputs/connlist/example_pods_w_same_owner_and_labels_gap_with_good_match_expression_connlist_output.txt
+++ b/test_outputs/connlist/example_pods_w_same_owner_and_labels_gap_with_good_match_expression_connlist_output.txt
@@ -1,0 +1,4 @@
+default/internal-security[Pod] => 0.0.0.0-255.255.255.255 : All Connections
+default/internal-security[Pod] => default/pod-3[Pod] : TCP 90
+default/pod-3[Pod] => 0.0.0.0-255.255.255.255 : All Connections
+default/pod-3[Pod] => default/internal-security[Pod] : TCP 90

--- a/test_outputs/connlist/example_pods_w_same_owner_and_labels_gap_with_policy_selector_not_in_gap_connlist_output.txt
+++ b/test_outputs/connlist/example_pods_w_same_owner_and_labels_gap_with_policy_selector_not_in_gap_connlist_output.txt
@@ -1,0 +1,3 @@
+default/internal-security[Pod] => 0.0.0.0-255.255.255.255 : All Connections
+default/internal-security[Pod] => default/pod-3[Pod] : TCP 8050
+default/pod-3[Pod] => 0.0.0.0-255.255.255.255 : All Connections

--- a/tests/example_pods_w_same_owner_and_labels_gap_anp_good/anp.yaml
+++ b/tests/example_pods_w_same_owner_and_labels_gap_anp_good/anp.yaml
@@ -1,0 +1,31 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: new-example
+spec:
+  priority: 10
+  subject:
+    pods: # subject selecting pods with labels not in the gap
+      podSelector:
+        matchLabels:
+          security: internal
+  ingress:
+  - name: "allow-tcp-80-from-pod3" 
+    action: "Allow"
+    from:
+    - pods:
+        podSelector:
+          matchLabels:
+            app: pod3
+    ports:
+    - portNumber:
+        port: 80
+        protocol: TCP
+  - name: "deny-others" 
+    action: "Deny"
+    from:
+    - pods:
+        podSelector:
+          matchLabels:
+            app: pod3
+---

--- a/tests/example_pods_w_same_owner_and_labels_gap_anp_good/pods.yaml
+++ b/tests/example_pods_w_same_owner_and_labels_gap_anp_good/pods.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+  labels:
+    kubernetes.io/metadata.name: default
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-1
+  labels:
+    security: internal
+    app: command-selector
+    tier: agent
+  ownerReferences:
+    - name: internal-security
+      controller: true
+spec:
+  containers:
+    - name: myfirstcontainer
+      image: pod1image
+
+---
+# a pod in same owner is pod-1 but some different labels
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-2
+  labels:
+    security: internal
+    app: query-selector
+    tier: analyzer
+  ownerReferences:
+    - name: internal-security
+      controller: true
+spec:
+  containers:
+    - name: mycontainer
+      image: pod2image
+
+---
+# another pod in default ns - not having an owner
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-3
+  labels: 
+    app: pod3
+spec:
+  containers:
+    - name: mycontainer
+      image: pod3image

--- a/tests/example_pods_w_same_owner_and_labels_gap_banp_good/banp.yaml
+++ b/tests/example_pods_w_same_owner_and_labels_gap_banp_good/banp.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: BaselineAdminNetworkPolicy
+metadata:
+  name: default
+spec:
+  subject:
+    pods:
+      podSelector:
+        matchLabels:
+          app: pod3
+  egress:
+  - name: "deny-everything" 
+    action: "Deny"
+    to:
+    - pods:
+        podSelector:
+          matchLabels:
+            security: internal

--- a/tests/example_pods_w_same_owner_and_labels_gap_banp_good/pods.yaml
+++ b/tests/example_pods_w_same_owner_and_labels_gap_banp_good/pods.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+  labels:
+    kubernetes.io/metadata.name: default
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-1
+  labels:
+    security: internal
+    app: command-selector
+    tier: agent
+  ownerReferences:
+    - name: internal-security
+      controller: true
+spec:
+  containers:
+    - name: myfirstcontainer
+      image: pod1image
+
+---
+# a pod in same owner is pod-1 but some different labels
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-2
+  labels:
+    security: internal
+    app: query-selector
+    tier: analyzer
+  ownerReferences:
+    - name: internal-security
+      controller: true
+spec:
+  containers:
+    - name: mycontainer
+      image: pod2image
+
+---
+# another pod in default ns - not having an owner
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-3
+  labels: 
+    app: pod3
+spec:
+  containers:
+    - name: mycontainer
+      image: pod3image

--- a/tests/example_pods_w_same_owner_and_labels_gap_no_policy/pods.yaml
+++ b/tests/example_pods_w_same_owner_and_labels_gap_no_policy/pods.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+  labels:
+    kubernetes.io/metadata.name: default
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-1
+  labels:
+    security: internal
+    app: command-selector
+    tier: agent
+  ownerReferences:
+    - name: internal-security
+      controller: true
+spec:
+  containers:
+    - name: myfirstcontainer
+      image: pod1image
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-2
+  labels:
+    security: internal
+    app: query-selector
+    tier: analyzer
+  ownerReferences:
+    - name: internal-security
+      controller: true
+spec:
+  containers:
+    - name: mycontainer
+      image: pod2image

--- a/tests/example_pods_w_same_owner_and_labels_gap_with_bad_match_expression/netpol.yaml
+++ b/tests/example_pods_w_same_owner_and_labels_gap_with_bad_match_expression/netpol.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: use_common_labels_same_values
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchExpressions:
+        - key: app
+          operator: In
+          values:
+          - query-selector
+    ports:
+    - port: 90
+      protocol: TCP
+
+---

--- a/tests/example_pods_w_same_owner_and_labels_gap_with_bad_match_expression/pods.yaml
+++ b/tests/example_pods_w_same_owner_and_labels_gap_with_bad_match_expression/pods.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+  labels:
+    kubernetes.io/metadata.name: default
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-1
+  labels:
+    security: internal
+    app: command-selector
+    tier: agent
+  ownerReferences:
+    - name: internal-security
+      controller: true
+spec:
+  containers:
+    - name: myfirstcontainer
+      image: pod1image
+
+---
+# a pod in same owner is pod-1 but some different labels
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-2
+  labels:
+    security: internal
+    app: query-selector
+    tier: analyzer
+  ownerReferences:
+    - name: internal-security
+      controller: true
+spec:
+  containers:
+    - name: mycontainer
+      image: pod2image
+
+---
+# another pod in default ns - not having an owner
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-3
+  labels: 
+    app: pod3
+spec:
+  containers:
+    - name: mycontainer
+      image: pod3image

--- a/tests/example_pods_w_same_owner_and_labels_gap_with_good_match_expression/netpol.yaml
+++ b/tests/example_pods_w_same_owner_and_labels_gap_with_good_match_expression/netpol.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: use_common_labels_same_values
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchExpressions:
+        - key: app
+          operator: Exists
+    ports:
+    - port: 90
+      protocol: TCP
+
+---

--- a/tests/example_pods_w_same_owner_and_labels_gap_with_good_match_expression/pods.yaml
+++ b/tests/example_pods_w_same_owner_and_labels_gap_with_good_match_expression/pods.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+  labels:
+    kubernetes.io/metadata.name: default
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-1
+  labels:
+    security: internal
+    app: command-selector
+    tier: agent
+  ownerReferences:
+    - name: internal-security
+      controller: true
+spec:
+  containers:
+    - name: myfirstcontainer
+      image: pod1image
+
+---
+# a pod in same owner is pod-1 but some different labels
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-2
+  labels:
+    security: internal
+    app: query-selector
+    tier: analyzer
+  ownerReferences:
+    - name: internal-security
+      controller: true
+spec:
+  containers:
+    - name: mycontainer
+      image: pod2image
+
+---
+# another pod in default ns - not having an owner
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-3
+  labels: 
+    app: pod3
+spec:
+  containers:
+    - name: mycontainer
+      image: pod3image

--- a/tests/example_pods_w_same_owner_and_labels_gap_with_good_match_expression2/netpol.yaml
+++ b/tests/example_pods_w_same_owner_and_labels_gap_with_good_match_expression2/netpol.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: use_match_exp_with_all_gap_values_of_app
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchExpressions:
+        - key: app
+          operator: In
+          values:
+          - query-selector
+          - command-selector
+    ports:
+    - port: 90
+      protocol: TCP
+
+---

--- a/tests/example_pods_w_same_owner_and_labels_gap_with_good_match_expression2/pods.yaml
+++ b/tests/example_pods_w_same_owner_and_labels_gap_with_good_match_expression2/pods.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+  labels:
+    kubernetes.io/metadata.name: default
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-1
+  labels:
+    security: internal
+    app: command-selector
+    tier: agent
+  ownerReferences:
+    - name: internal-security
+      controller: true
+spec:
+  containers:
+    - name: myfirstcontainer
+      image: pod1image
+
+---
+# a pod in same owner is pod-1 but some different labels
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-2
+  labels:
+    security: internal
+    app: query-selector
+    tier: analyzer
+  ownerReferences:
+    - name: internal-security
+      controller: true
+spec:
+  containers:
+    - name: mycontainer
+      image: pod2image
+
+---
+# another pod in default ns - not having an owner
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-3
+  labels: 
+    app: pod3
+spec:
+  containers:
+    - name: mycontainer
+      image: pod3image

--- a/tests/example_pods_w_same_owner_and_labels_gap_with_policy_selector_not_in_gap/netpol.yaml
+++ b/tests/example_pods_w_same_owner_and_labels_gap_with_policy_selector_not_in_gap/netpol.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: use_common_labels_same_values
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          security: internal
+    ports:
+    - port: 8050
+      protocol: TCP
+
+---

--- a/tests/example_pods_w_same_owner_and_labels_gap_with_policy_selector_not_in_gap/pods.yaml
+++ b/tests/example_pods_w_same_owner_and_labels_gap_with_policy_selector_not_in_gap/pods.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+  labels:
+    kubernetes.io/metadata.name: default
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-1
+  labels:
+    security: internal
+    app: command-selector
+    tier: agent
+  ownerReferences:
+    - name: internal-security
+      controller: true
+spec:
+  containers:
+    - name: myfirstcontainer
+      image: pod1image
+
+---
+# a pod in same owner is pod-1 but some different labels
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-2
+  labels:
+    security: internal
+    app: query-selector
+    tier: analyzer
+  ownerReferences:
+    - name: internal-security
+      controller: true
+spec:
+  containers:
+    - name: mycontainer
+      image: pod2image
+
+---
+# another pod in default ns - not having an owner
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-3
+  labels: 
+    app: pod3
+spec:
+  containers:
+    - name: mycontainer
+      image: pod3image

--- a/tests/example_w_err_pods_w_same_owner_and_labels_gap_anp/anp.yaml
+++ b/tests/example_w_err_pods_w_same_owner_and_labels_gap_anp/anp.yaml
@@ -1,0 +1,24 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: new-example-with-err
+spec:
+  priority: 10
+  subject:
+    pods: # subject selecting pods with gap-labels
+      podSelector:
+        matchLabels:
+          app: command-selector
+  ingress:
+  - name: "pass-tcp-80-from-ns2" 
+    action: "Pass"
+    from:
+    - pods:
+        podSelector:
+          matchLabels:
+            app: pod3
+    ports:
+    - portNumber:
+        port: 80
+        protocol: TCP
+---

--- a/tests/example_w_err_pods_w_same_owner_and_labels_gap_anp/pods.yaml
+++ b/tests/example_w_err_pods_w_same_owner_and_labels_gap_anp/pods.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+  labels:
+    kubernetes.io/metadata.name: default
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-1
+  labels:
+    security: internal
+    app: command-selector
+    tier: agent
+  ownerReferences:
+    - name: internal-security
+      controller: true
+spec:
+  containers:
+    - name: myfirstcontainer
+      image: pod1image
+
+---
+# a pod in same owner is pod-1 but some different labels
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-2
+  labels:
+    security: internal
+    app: query-selector
+    tier: analyzer
+  ownerReferences:
+    - name: internal-security
+      controller: true
+spec:
+  containers:
+    - name: mycontainer
+      image: pod2image
+
+---
+# another pod in default ns - not having an owner
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-3
+  labels: 
+    app: pod3
+spec:
+  containers:
+    - name: mycontainer
+      image: pod3image


### PR DESCRIPTION
#480 

currently:
- code with first approach : generating error if its not possible to analyze-connectivity when `createPodOwnersMap` (by looping policies' selectors)

- multiple examples


~- [ ] possible to enhance the performance by generating the errors on the flow of computing allowed-conns between peers~
moved to a new issue #553