### PR TITLE
Updates for a new version

### DIFF
--- a/pkg/netpol/connlist/connlist.go
+++ b/pkg/netpol/connlist/connlist.go
@@ -774,7 +774,11 @@ func (ca *ConnlistAnalyzer) getConnectionsList(pe *eval.PolicyEngine, ia *ingres
 	// log warnings that were raised by the policies during computing the allowed conns between all peers
 	// note that this ensures any warning is printed only once + all relevant warnings are raised.
 	// the decision if to print the warnings to the logger is determined by the logger's verbosity - handled by the logger
-	pe.LogPoliciesWarnings()
+	policiesWarns := pe.LogPoliciesWarnings()
+	// policiesWarns already printed to the logger, add them also to the ca.Errors API system
+	for _, warn := range policiesWarns {
+		ca.errors = append(ca.errors, newConnlistAnalyzerWarning(errors.New(warn)))
+	}
 
 	connsRes = peersAllowedConns
 

--- a/pkg/netpol/eval/internal/k8s/adminnetpol.go
+++ b/pkg/netpol/eval/internal/k8s/adminnetpol.go
@@ -190,8 +190,8 @@ func (anp *AdminNetworkPolicy) GetReferencedIPBlocks() ([]*netset.IPBlock, error
 	return res, nil
 }
 
-func (anp *AdminNetworkPolicy) LogWarnings(l logger.Logger) {
-	anp.warnings.LogPolicyWarnings(l)
+func (anp *AdminNetworkPolicy) LogWarnings(l logger.Logger) []string {
+	return anp.warnings.LogPolicyWarnings(l)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/pkg/netpol/eval/internal/k8s/baseline_admin_netpol.go
+++ b/pkg/netpol/eval/internal/k8s/baseline_admin_netpol.go
@@ -192,8 +192,8 @@ func (banp *BaselineAdminNetworkPolicy) GetReferencedIPBlocks() ([]*netset.IPBlo
 	return res, nil
 }
 
-func (banp *BaselineAdminNetworkPolicy) LogWarnings(l logger.Logger) {
-	banp.warnings.LogPolicyWarnings(l)
+func (banp *BaselineAdminNetworkPolicy) LogWarnings(l logger.Logger) []string {
+	return banp.warnings.LogPolicyWarnings(l)
 }
 
 // /////////////////////////////////////////////////////////////

--- a/pkg/netpol/eval/internal/k8s/netpol.go
+++ b/pkg/netpol/eval/internal/k8s/netpol.go
@@ -581,8 +581,8 @@ func (np *NetworkPolicy) ruleName(ruleIdx int, isIngress bool) string {
 	return fmt.Sprintf("%s rule #%d", directionName(isIngress), ruleIdx+1)
 }
 
-func (np *NetworkPolicy) LogWarnings(l logger.Logger) {
-	np.warnings.LogPolicyWarnings(l)
+func (np *NetworkPolicy) LogWarnings(l logger.Logger) []string {
+	return np.warnings.LogPolicyWarnings(l)
 }
 
 //////////////////////////////////////////////// ////////////////////////////////////////////////

--- a/pkg/netpol/eval/resources.go
+++ b/pkg/netpol/eval/resources.go
@@ -1056,19 +1056,21 @@ func (pe *PolicyEngine) addRepresentativePod(podNs string, objSelectors *k8s.Sin
 // calling this func once after all computations are done, ensures that :
 // - all relevant warnings from looping policy rules are raised
 // - each single warning is printed only once to the logger
-func (pe *PolicyEngine) LogPoliciesWarnings() {
+// - all warns are returned also as []string
+func (pe *PolicyEngine) LogPoliciesWarnings() (warns []string) {
 	// log warnings from k8s NetworkPolicy objects
 	for _, nsMap := range pe.netpolsMap {
 		for _, policy := range nsMap {
-			policy.LogWarnings(pe.logger)
+			warns = append(warns, policy.LogWarnings(pe.logger)...)
 		}
 	}
 	// log warnings from AdminNetworkPolicy objects
 	for _, anp := range pe.sortedAdminNetpols {
-		anp.LogWarnings(pe.logger)
+		warns = append(warns, anp.LogWarnings(pe.logger)...)
 	}
 	// log warnings from the BaselineAdminNetworkPolicy
 	if pe.baselineAdminNetpol != nil {
-		pe.baselineAdminNetpol.LogWarnings(pe.logger)
+		warns = append(warns, pe.baselineAdminNetpol.LogWarnings(pe.logger)...)
 	}
+	return warns
 }

--- a/pkg/netpol/internal/alerts/warnings.go
+++ b/pkg/netpol/internal/alerts/warnings.go
@@ -46,8 +46,8 @@ func BlockedIngressWarning(objKind, objName, peerStr string) string {
 }
 
 func WarnIncompatibleFormat(format string) string {
-	return fmt.Sprintf("explainability is available only with %s format."+
-		" A connlist without explainability will be printed for the input format %s", output.DefaultFormat, format)
+	return fmt.Sprintf("explain flag is supported only with %s output format;"+
+		" ignoring this flag for the required output format %s", output.DefaultFormat, format)
 }
 
 func WarnUnmatchedNamedPort(namedPort, peerStr string) string {

--- a/pkg/netpol/internal/common/warning_set.go
+++ b/pkg/netpol/internal/common/warning_set.go
@@ -18,8 +18,14 @@ func (w Warnings) AddWarning(warning string) {
 }
 
 // LogPolicyWarnings logs current warnings into the given logger
-func (w Warnings) LogPolicyWarnings(l logger.Logger) {
+// and returns the warnings for connlist API propagation goals
+func (w Warnings) LogPolicyWarnings(l logger.Logger) []string {
+	res := make([]string, len(w))
+	i := 0
 	for warning := range w {
 		l.Warnf(warning)
+		res[i] = warning
+		i++
 	}
+	return res
 }


### PR DESCRIPTION
- updating the warning of using explain with an output-format other that `txt`
- propagating also policies warns through connlist analyzer API