### PR TITLE
Bug fix for issue571

### DIFF
--- a/pkg/netpol/connlist/explanation_test.go
+++ b/pkg/netpol/connlist/explanation_test.go
@@ -65,6 +65,9 @@ var explainTests = []struct {
 	supportedOnLiveCluster bool
 }{
 	{
+		testDirName: "netpol-demo",
+	},
+	{
 		testDirName: "acs-security-demos",
 	},
 	{

--- a/pkg/netpol/internal/common/augmented_intervalset.go
+++ b/pkg/netpol/internal/common/augmented_intervalset.go
@@ -341,9 +341,6 @@ const (
 func (rules ImplyingXgressRulesType) update(other ImplyingXgressRulesType, sameInclusion bool,
 	collectStyle CollectStyleType) ImplyingXgressRulesType {
 	result := rules.Copy()
-	if other.Empty() {
-		return result
-	}
 	if collectStyle == AlwaysCollectRules || (collectStyle == CollectSameInclusionRules && sameInclusion) {
 		result.Union(other)
 		return result
@@ -455,6 +452,12 @@ func NewAugmentedCanonicalSetWithRules(minValue, maxValue int64, isAll bool, rul
 func (c *AugmentedCanonicalSet) RemoveDefaultRule(isIngress bool) {
 	for ind := range c.intervalSet {
 		c.intervalSet[ind].implyingRules.RemoveDefaultRule(isIngress)
+	}
+}
+
+func (c *AugmentedCanonicalSet) CleanImplyingRules() {
+	for ind := range c.intervalSet {
+		c.intervalSet[ind].implyingRules = InitImplyingRules()
 	}
 }
 

--- a/pkg/netpol/internal/common/connectionset.go
+++ b/pkg/netpol/internal/common/connectionset.go
@@ -76,6 +76,13 @@ func (conn *ConnectionSet) RemoveDefaultRule(isIngress bool) {
 	}
 }
 
+func (conn *ConnectionSet) CleanImplyingRules() {
+	conn.CommonImplyingRules = InitImplyingRules()
+	for _, ports := range conn.AllowedProtocols {
+		ports.CleanImplyingRules()
+	}
+}
+
 // GetAllTCPConnections returns a pointer to ConnectionSet object with all TCP protocol connections
 func GetAllTCPConnections() *ConnectionSet {
 	tcpConn := MakeConnectionSet(false)

--- a/pkg/netpol/internal/common/portset.go
+++ b/pkg/netpol/internal/common/portset.go
@@ -66,6 +66,10 @@ func (p *PortSet) RemoveDefaultRule(isIngress bool) {
 	p.Ports.RemoveDefaultRule(isIngress)
 }
 
+func (p *PortSet) CleanImplyingRules() {
+	p.Ports.CleanImplyingRules()
+}
+
 // Equal: return true if current object equals another PortSet object
 // Ports are equal if they have same allowed port-numbers and same allowed named-ports
 func (p *PortSet) Equal(other *PortSet) bool {

--- a/test_outputs/connlist/netpol-demo_explain_output.txt
+++ b/test_outputs/connlist/netpol-demo_explain_output.txt
@@ -1,0 +1,210 @@
+
+##########################################
+# Specific connections and their reasons #
+##########################################
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between 0.0.0.0-255.255.255.255[External] => bar/mybar[Pod]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'bar/bar-default-deny' selects bar/mybar[Pod], but 0.0.0.0-255.255.255.255[External] is not allowed by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between 0.0.0.0-255.255.255.255[External] => baz/mybaz[Pod]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'baz/baz-default-deny' selects baz/mybaz[Pod], but 0.0.0.0-255.255.255.255[External] is not allowed by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between 0.0.0.0-255.255.255.255[External] => foo/myfoo[Pod]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy list:
+				- NetworkPolicy 'foo/allow-monitoring' selects foo/myfoo[Pod], but 0.0.0.0-255.255.255.255[External] is not allowed by any Ingress rule
+				- NetworkPolicy 'foo/foo-default-deny' selects foo/myfoo[Pod], but 0.0.0.0-255.255.255.255[External] is not allowed by any Ingress rule (no rules defined)
+
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between 0.0.0.0-255.255.255.255[External] => monitoring/mymonitoring[Pod]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed) due to the system default (Allow all)
+		Ingress (Denied)
+			NetworkPolicy 'monitoring/monitoring-default-deny' selects monitoring/mymonitoring[Pod], but 0.0.0.0-255.255.255.255[External] is not allowed by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between bar/mybar[Pod] => 0.0.0.0-255.255.255.255[External]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'bar/bar-default-deny' selects bar/mybar[Pod], but 0.0.0.0-255.255.255.255[External] is not allowed by any Egress rule (no rules defined)
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between bar/mybar[Pod] => baz/mybaz[Pod]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'bar/bar-default-deny' selects bar/mybar[Pod], but baz/mybaz[Pod] is not allowed by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'baz/baz-default-deny' selects baz/mybaz[Pod], but bar/mybar[Pod] is not allowed by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between bar/mybar[Pod] => foo/myfoo[Pod]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'bar/bar-default-deny' selects bar/mybar[Pod], but foo/myfoo[Pod] is not allowed by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy list:
+				- NetworkPolicy 'foo/allow-monitoring' selects foo/myfoo[Pod], but bar/mybar[Pod] is not allowed by any Ingress rule
+				- NetworkPolicy 'foo/foo-default-deny' selects foo/myfoo[Pod], but bar/mybar[Pod] is not allowed by any Ingress rule (no rules defined)
+
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between bar/mybar[Pod] => monitoring/mymonitoring[Pod]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'bar/bar-default-deny' selects bar/mybar[Pod], but monitoring/mymonitoring[Pod] is not allowed by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'monitoring/monitoring-default-deny' selects monitoring/mymonitoring[Pod], but bar/mybar[Pod] is not allowed by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between baz/mybaz[Pod] => 0.0.0.0-255.255.255.255[External]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'baz/baz-default-deny' selects baz/mybaz[Pod], but 0.0.0.0-255.255.255.255[External] is not allowed by any Egress rule (no rules defined)
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between baz/mybaz[Pod] => bar/mybar[Pod]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'baz/baz-default-deny' selects baz/mybaz[Pod], but bar/mybar[Pod] is not allowed by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'bar/bar-default-deny' selects bar/mybar[Pod], but baz/mybaz[Pod] is not allowed by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between baz/mybaz[Pod] => foo/myfoo[Pod]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'baz/baz-default-deny' selects baz/mybaz[Pod], but foo/myfoo[Pod] is not allowed by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy list:
+				- NetworkPolicy 'foo/allow-monitoring' selects foo/myfoo[Pod], but baz/mybaz[Pod] is not allowed by any Ingress rule
+				- NetworkPolicy 'foo/foo-default-deny' selects foo/myfoo[Pod], but baz/mybaz[Pod] is not allowed by any Ingress rule (no rules defined)
+
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between baz/mybaz[Pod] => monitoring/mymonitoring[Pod]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'baz/baz-default-deny' selects baz/mybaz[Pod], but monitoring/mymonitoring[Pod] is not allowed by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'monitoring/monitoring-default-deny' selects monitoring/mymonitoring[Pod], but baz/mybaz[Pod] is not allowed by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between foo/myfoo[Pod] => 0.0.0.0-255.255.255.255[External]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'foo/foo-default-deny' selects foo/myfoo[Pod], but 0.0.0.0-255.255.255.255[External] is not allowed by any Egress rule (no rules defined)
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between foo/myfoo[Pod] => bar/mybar[Pod]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'foo/foo-default-deny' selects foo/myfoo[Pod], but bar/mybar[Pod] is not allowed by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'bar/bar-default-deny' selects bar/mybar[Pod], but foo/myfoo[Pod] is not allowed by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between foo/myfoo[Pod] => baz/mybaz[Pod]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'foo/foo-default-deny' selects foo/myfoo[Pod], but baz/mybaz[Pod] is not allowed by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'baz/baz-default-deny' selects baz/mybaz[Pod], but foo/myfoo[Pod] is not allowed by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between foo/myfoo[Pod] => monitoring/mymonitoring[Pod]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy 'foo/foo-default-deny' selects foo/myfoo[Pod], but monitoring/mymonitoring[Pod] is not allowed by any Egress rule (no rules defined)
+		Ingress (Denied)
+			NetworkPolicy 'monitoring/monitoring-default-deny' selects monitoring/mymonitoring[Pod], but foo/myfoo[Pod] is not allowed by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between monitoring/mymonitoring[Pod] => 0.0.0.0-255.255.255.255[External]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Denied)
+			NetworkPolicy list:
+				- NetworkPolicy 'monitoring/monitoring-allow-egress-to-all-namespaces' selects monitoring/mymonitoring[Pod], but 0.0.0.0-255.255.255.255[External] is not allowed by any Egress rule
+				- NetworkPolicy 'monitoring/monitoring-default-deny' selects monitoring/mymonitoring[Pod], but 0.0.0.0-255.255.255.255[External] is not allowed by any Egress rule (no rules defined)
+
+		Ingress (Allowed) due to the system default (Allow all)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between monitoring/mymonitoring[Pod] => bar/mybar[Pod]:
+
+Denied connections:
+	Denied TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed)
+			NetworkPolicy 'monitoring/monitoring-allow-egress-to-all-namespaces' allows connections by Egress rule #1
+		Ingress (Denied)
+			AdminNetworkPolicy 'pass-monitoring' passes connections by Ingress rule pass-ingress-from-monitoring
+			NetworkPolicy 'bar/bar-default-deny' selects bar/mybar[Pod], but monitoring/mymonitoring[Pod] is not allowed by any Ingress rule (no rules defined)
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between monitoring/mymonitoring[Pod] => baz/mybaz[Pod]:
+
+Allowed connections:
+	Allowed TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed)
+			NetworkPolicy 'monitoring/monitoring-allow-egress-to-all-namespaces' allows connections by Egress rule #1
+		Ingress (Allowed)
+			AdminNetworkPolicy 'allow-monitoring' allows connections by Ingress rule allow-ingress-from-monitoring
+
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Connections between monitoring/mymonitoring[Pod] => foo/myfoo[Pod]:
+
+Allowed connections:
+	Allowed TCP, UDP, SCTP due to the following policies and rules:
+		Egress (Allowed)
+			NetworkPolicy 'monitoring/monitoring-allow-egress-to-all-namespaces' allows connections by Egress rule #1
+		Ingress (Allowed)
+			AdminNetworkPolicy 'pass-monitoring' passes connections by Ingress rule pass-ingress-from-monitoring
+			NetworkPolicy 'foo/allow-monitoring' allows connections by Ingress rule #1
+


### PR DESCRIPTION
Bug fix: when collecting multiple ANP connections, don't propagate explainability of `PassConns` into `AllowedConns` and `DeniedConns`.
Added netpol-demo to explainability test base.