### PR TITLE
adding multiple-networks switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Global Flags:
       --fail                fail on the first encountered error
       --include-json        consider JSON manifests (in addition to YAML) when analyzing from dir
   -k, --kubeconfig string   Path and file to use for kubeconfig when evaluating connections in a live cluster
+      --multiple-networks   Enables analysis of multi-network resources such as UserDefinedNetwork, NetworkAttachmentDefinition, and MultiNetworkPolicy. If disabled, these resources will be ignored (default "true").
   -q, --quiet               Runs quietly, reports only severe errors and results
   -v, --verbose             Runs with more informative messages printed to log
 ```
@@ -77,6 +78,7 @@ Global Flags:
       --dirpath     string    Resources dir path when evaluating connections from a dir
       --fail                  fail on the first encountered error
   -k, --kubeconfig  string    Path and file to use for kubeconfig when evaluating connections in a live cluster
+      --multiple-networks     Enables analysis of multi-network resources such as UserDefinedNetwork, NetworkAttachmentDefinition, and MultiNetworkPolicy. If disabled, these resources will be ignored (default "true").
   -q, --quiet                 runs quietly, reports only severe errors and results
   -v, --verbose               runs with more informative messages printed to log
 ```
@@ -105,6 +107,7 @@ Global Flags:
       --fail                fail on the first encountered error
       --include-json        consider JSON manifests (in addition to YAML) when analyzing from dir
   -k, --kubeconfig string   Path and file to use for kubeconfig when evaluating connections in a live cluster
+      --multiple-networks   Enables analysis of multi-network resources such as UserDefinedNetwork, NetworkAttachmentDefinition, and MultiNetworkPolicy. If disabled, these resources will be ignored (default "true").
   -q, --quiet               Runs quietly, reports only severe errors and results
   -v, --verbose             Runs with more informative messages printed to log  
 ```

--- a/pkg/cli/diff.go
+++ b/pkg/cli/diff.go
@@ -57,6 +57,9 @@ func getDiffOptions(l *logger.DefaultLogger) []diff.DiffAnalyzerOption {
 	if stopOnFirstError {
 		res = append(res, diff.WithStopOnError())
 	}
+	if multipleNetworks {
+		res = append(res, diff.WithMultipleNetworks())
+	}
 	return res
 }
 

--- a/pkg/cli/evaluate.go
+++ b/pkg/cli/evaluate.go
@@ -89,7 +89,8 @@ func updatePolicyEngineObjectsFromDirPath(pe *eval.PolicyEngine, podNames []type
 			eLogger.Errorf(err, netpolerrors.FailedReadingFileErrorStr) // print to log the error from builder
 		}
 	}
-	objectsList, processingErrs := parser.ResourceInfoListToK8sObjectsList(rList, eLogger, false)
+	// @todo: add support of NAD and MultiNP; eval currently supports (C)UDN
+	objectsList, processingErrs := parser.ResourceInfoListToK8sObjectsList(rList, eLogger, false, multipleNetworks)
 	for _, err := range processingErrs {
 		if err.IsFatal() || (stopOnFirstError && err.IsSevere()) {
 			return fmt.Errorf("scan dir path %s had processing errors: %w", dirPath, err.Error())

--- a/pkg/cli/list.go
+++ b/pkg/cli/list.go
@@ -97,6 +97,9 @@ func getConnlistOptions(l *logger.DefaultLogger) []connlist.ConnlistAnalyzerOpti
 	if explain {
 		res = append(res, connlist.WithExplanation())
 	}
+	if multipleNetworks {
+		res = append(res, connlist.WithMultipleNetworks())
+	}
 	return res
 }
 

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -31,6 +31,7 @@ var (
 	quiet              bool
 	verbose            bool
 	stopOnFirstError   bool
+	multipleNetworks   bool // support multiple networks in the cluster
 )
 
 // returns verbosity level based on the -q and -v switches
@@ -97,6 +98,8 @@ func newCommandRoot() *cobra.Command {
 	c.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "runs quietly, reports only severe errors and results")
 	c.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "runs with more informative messages printed to log")
 	c.PersistentFlags().BoolVarP(&stopOnFirstError, "fail", "", false, "fail on the first encountered error")
+	c.PersistentFlags().BoolVarP(&multipleNetworks, "multiple-networks", "", true, "Enable analysis of multi-network resources such as"+
+		" UserDefinedNetwork, NetworkAttachmentDefinition, and MultiNetworkPolicy. If disabled, these resources will be ignored.")
 
 	// add sub-commands
 	c.AddCommand(newCommandEvaluate())

--- a/pkg/internal/testutils/testutils.go
+++ b/pkg/internal/testutils/testutils.go
@@ -179,7 +179,8 @@ func generateGraphFilesIfPossible(dotFilePath string) {
 	}
 	// generate png file (this png file is generated for the dot format; however svg is a supported output format)
 	graphFilePath := dotFilePath + dotSign + graphSuffix
-	cmd := exec.Command(output.GraphvizExecutable, dotFilePath, "-T"+graphSuffix, "-o", graphFilePath) //nolint:gosec // nosec
+	cmd := exec.Command(output.GraphvizExecutable, dotFilePath, "-T"+graphSuffix, "-o", graphFilePath) //nolint:noctx,gosec // nosec,
+	// context is not needed here
 	if err := cmd.Run(); err != nil {
 		logger.NewDefaultLogger().Warnf("failed generating %q; unexpected error: %v", graphFilePath, err)
 	}

--- a/pkg/manifests/fsscanner/manifests_test.go
+++ b/pkg/manifests/fsscanner/manifests_test.go
@@ -23,7 +23,7 @@ func TestBasic(t *testing.T) {
 	require.Empty(t, errs, "expecting no errors on basic dir")
 
 	// TODO: move the code below to parser pkg
-	oList, _ := parser.ResourceInfoListToK8sObjectsList(rList, logger.NewDefaultLogger(), false)
+	oList, _ := parser.ResourceInfoListToK8sObjectsList(rList, logger.NewDefaultLogger(), false, false)
 	require.Equal(t, len(oList), len(rList), "expecting same length fot input and output lists")
 	fmt.Println("done")
 }

--- a/pkg/manifests/parser/k8sobj.go
+++ b/pkg/manifests/parser/k8sobj.go
@@ -98,7 +98,8 @@ type K8sObject struct {
 }
 
 //gocyclo:ignore
-func (k *K8sObject) getEmptyInitializedFieldObjByKind(kind string) interface{} { //nolint:funlen // should not break this up
+func (k *K8sObject) getEmptyInitializedFieldObjByKind(kind string, //nolint:funlen // should not break this up
+	multipleNetworksEnabled bool) interface{} {
 	switch kind {
 	case Deployment:
 		k.Deployment = &appsv1.Deployment{}
@@ -146,20 +147,28 @@ func (k *K8sObject) getEmptyInitializedFieldObjByKind(kind string) interface{} {
 		k.BaselineAdminNetworkPolicy = &apisv1a.BaselineAdminNetworkPolicy{}
 		return k.BaselineAdminNetworkPolicy
 	case UserDefinedNetwork:
-		k.UserDefinedNetwork = &udnv1.UserDefinedNetwork{}
-		return k.UserDefinedNetwork
+		if multipleNetworksEnabled {
+			k.UserDefinedNetwork = &udnv1.UserDefinedNetwork{}
+			return k.UserDefinedNetwork
+		}
 	case ClusterUserDefinedNetwork:
-		k.ClusterUserDefinedNetwork = &udnv1.ClusterUserDefinedNetwork{}
-		return k.ClusterUserDefinedNetwork
+		if multipleNetworksEnabled {
+			k.ClusterUserDefinedNetwork = &udnv1.ClusterUserDefinedNetwork{}
+			return k.ClusterUserDefinedNetwork
+		}
 	case NetworkAttachmentDefinition:
-		k.NetworkAttachmentDefinition = &nadv1.NetworkAttachmentDefinition{}
-		return k.NetworkAttachmentDefinition
+		if multipleNetworksEnabled {
+			k.NetworkAttachmentDefinition = &nadv1.NetworkAttachmentDefinition{}
+			return k.NetworkAttachmentDefinition
+		}
 	case VirtualMachine:
 		k.VirtualMachine = &kubevirt.VirtualMachine{}
 		return k.VirtualMachine
 	case MultiNetworkPolicy:
-		k.MultiNetworkPolicy = &mnpv1.MultiNetworkPolicy{}
-		return k.MultiNetworkPolicy
+		if multipleNetworksEnabled {
+			k.MultiNetworkPolicy = &mnpv1.MultiNetworkPolicy{}
+			return k.MultiNetworkPolicy
+		}
 	}
 	return nil
 }

--- a/pkg/manifests/parser/k8sobj.go
+++ b/pkg/manifests/parser/k8sobj.go
@@ -162,8 +162,10 @@ func (k *K8sObject) getEmptyInitializedFieldObjByKind(kind string, //nolint:funl
 			return k.NetworkAttachmentDefinition
 		}
 	case VirtualMachine:
-		k.VirtualMachine = &kubevirt.VirtualMachine{}
-		return k.VirtualMachine
+		if multipleNetworksEnabled {
+			k.VirtualMachine = &kubevirt.VirtualMachine{}
+			return k.VirtualMachine
+		}
 	case MultiNetworkPolicy:
 		if multipleNetworksEnabled {
 			k.MultiNetworkPolicy = &mnpv1.MultiNetworkPolicy{}

--- a/pkg/netpol/connlist/connlist.go
+++ b/pkg/netpol/connlist/connlist.go
@@ -56,6 +56,7 @@ type ConnlistAnalyzer struct {
 	exposureAnalysis   bool
 	exposureResult     []ExposedPeer
 	explain            bool
+	multipleNetworks   bool
 	explainOnly        string
 	focusConnection    string
 	outputFormat       string
@@ -108,7 +109,7 @@ func (ca *ConnlistAnalyzer) warnIncompatibleFlagsUsage() {
 // and the list of all workloads from the parsed resources
 func (ca *ConnlistAnalyzer) ConnlistFromResourceInfos(info []*resource.Info) ([]Peer2PeerConnection, []Peer, error) {
 	// convert resource.Info objects to k8s resources, filter irrelevant resources
-	objects, fpErrs := parser.ResourceInfoListToK8sObjectsList(info, ca.logger, ca.muteErrsAndWarns)
+	objects, fpErrs := parser.ResourceInfoListToK8sObjectsList(info, ca.logger, ca.muteErrsAndWarns, ca.multipleNetworks)
 	ca.copyFpErrs(fpErrs)
 	if ca.stopProcessing() {
 		if err := ca.hasFatalError(); err != nil {
@@ -230,6 +231,14 @@ func WithExplainOnly(explainOnly string) ConnlistAnalyzerOption {
 	}
 }
 
+// WithMultipleNetworks is a functional option which directs ConnlistAnalyzer to enable parsing and analyzing multiple-networks resources,
+// such as (Cluster)UserDefinedNetwork, NetworkAttachmentDefinition and MultiNetworkPolicy
+func WithMultipleNetworks() ConnlistAnalyzerOption {
+	return func(ca *ConnlistAnalyzer) {
+		ca.multipleNetworks = true
+	}
+}
+
 // WithOutputFormat is a functional option, allowing user to choose the output format txt/json/dot/csv/md.
 func WithOutputFormat(outputFormat string) ConnlistAnalyzerOption {
 	return func(p *ConnlistAnalyzer) {
@@ -253,6 +262,7 @@ func NewConnlistAnalyzer(options ...ConnlistAnalyzerOption) *ConnlistAnalyzer {
 		exposureAnalysis: false,
 		exposureResult:   nil,
 		explain:          false,
+		multipleNetworks: false,
 		errors:           []ConnlistError{},
 		outputFormat:     output.DefaultFormat,
 	}

--- a/pkg/netpol/connlist/connlist_mock_k8s_server_test.go
+++ b/pkg/netpol/connlist/connlist_mock_k8s_server_test.go
@@ -43,7 +43,7 @@ func TestConnlistOnMockK8sServer(t *testing.T) {
 			for _, format := range tt.outputFormats {
 				testutils.SkipRunningSVGTestOnGithub(t, format)
 				pTest := prepareTest(tt.testDirName, tt.focusWorkloads, tt.focusWorkloadPeers, tt.focusDirection, tt.focusConn,
-					format, tt.exposureAnalysis)
+					format, tt.exposureAnalysis, false)
 				runTest(t, pTest)
 			}
 		})
@@ -59,7 +59,7 @@ func TestConnlistWithExplanationOnMockK8sServer(t *testing.T) {
 		t.Run(tt.testDirName, func(t *testing.T) {
 			t.Parallel()
 			pTest := prepareExplainTest(tt.testDirName, tt.focusWorkloads, tt.focusWorkloadPeers, tt.focusDirection, tt.focusConn,
-				tt.explainOnly, tt.exposure)
+				tt.explainOnly, tt.exposure, false)
 			runTest(t, pTest)
 		})
 	}
@@ -67,7 +67,7 @@ func TestConnlistWithExplanationOnMockK8sServer(t *testing.T) {
 
 func runTest(t *testing.T, pTest preparedTest) {
 	infos, _ := fsscanner.GetResourceInfosFromDirPath([]string{pTest.dirPath}, true, false)
-	objects, _ := parser.ResourceInfoListToK8sObjectsList(infos, logger.NewDefaultLogger(), true)
+	objects, _ := parser.ResourceInfoListToK8sObjectsList(infos, logger.NewDefaultLogger(), true, false)
 
 	k8sClientset, policyAPIClientset, err := buildFakeClientsets(objects)
 	require.Nil(t, err, pTest.testInfo)

--- a/pkg/netpol/connlist/connlist_test.go
+++ b/pkg/netpol/connlist/connlist_test.go
@@ -86,7 +86,7 @@ func TestConnListFromDir(t *testing.T) {
 			for _, format := range tt.outputFormats {
 				testutils.SkipRunningSVGTestOnGithub(t, format)
 				pTest := prepareTest(tt.testDirName, tt.focusWorkloads, tt.focusWorkloadPeers, tt.focusDirection, tt.focusConn,
-					format, tt.exposureAnalysis)
+					format, tt.exposureAnalysis, tt.multipleNetworksEnabled)
 				res, _, err := pTest.analyzer.ConnlistFromDirPath(pTest.dirPath)
 				require.Nil(t, err, pTest.testInfo)
 				out, err := pTest.analyzer.ConnectionsListToString(res)
@@ -106,7 +106,7 @@ func TestConnListFromResourceInfos(t *testing.T) {
 			for _, format := range tt.outputFormats {
 				testutils.SkipRunningSVGTestOnGithub(t, format)
 				pTest := prepareTest(tt.testDirName, tt.focusWorkloads, tt.focusWorkloadPeers, tt.focusDirection, tt.focusConn,
-					format, tt.exposureAnalysis)
+					format, tt.exposureAnalysis, tt.multipleNetworksEnabled)
 				infos, _ := fsscanner.GetResourceInfosFromDirPath([]string{pTest.dirPath}, true, false)
 				// require.Empty(t, errs, testInfo) - TODO: add info about expected errors
 				// from each test here (these errors do not stop the analysis or affect the output)
@@ -130,9 +130,10 @@ func TestConnListFromResourceInfos(t *testing.T) {
 func TestConnlistAnalyzeFatalErrors(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name             string
-		dirName          string
-		errorStrContains string
+		name                    string
+		dirName                 string
+		errorStrContains        string
+		multipleNetworksEnabled bool
 	}{
 		// invalid netpols batch
 		{
@@ -379,51 +380,59 @@ func TestConnlistAnalyzeFatalErrors(t *testing.T) {
 			errorStrContains: alerts.NSWithSameNameError("blue"),
 		},
 		{
-			name:             "Input_udn_contains_invalid_value_for_key_topology_return_fatal_error",
-			dirName:          "udn_bad_path_test_1",
-			errorStrContains: alerts.InvalidKeyValue("blue/separate-namespace", "topology", "Layer4"),
+			name:                    "Input_udn_contains_invalid_value_for_key_topology_return_fatal_error",
+			dirName:                 "udn_bad_path_test_1",
+			errorStrContains:        alerts.InvalidKeyValue("blue/separate-namespace", "topology", "Layer4"),
+			multipleNetworksEnabled: true,
 		},
 		{
-			name:             "Input_udn_contains_mismatch_between_key_topology_and_actual_layer_return_fatal_error",
-			dirName:          "udn_bad_path_test_2",
-			errorStrContains: alerts.DisMatchLayerConfiguration("blue/separate-namespace", "Layer2"),
+			name:                    "Input_udn_contains_mismatch_between_key_topology_and_actual_layer_return_fatal_error",
+			dirName:                 "udn_bad_path_test_2",
+			errorStrContains:        alerts.DisMatchLayerConfiguration("blue/separate-namespace", "Layer2"),
+			multipleNetworksEnabled: true,
 		},
 		{
-			name:             "Input_udn_contains_invalid_value_for_key_role_return_fatal_error",
-			dirName:          "udn_bad_path_test_3",
-			errorStrContains: alerts.InvalidKeyValue("blue/separate-namespace", "role", "Admin"),
+			name:                    "Input_udn_contains_invalid_value_for_key_role_return_fatal_error",
+			dirName:                 "udn_bad_path_test_3",
+			errorStrContains:        alerts.InvalidKeyValue("blue/separate-namespace", "role", "Admin"),
+			multipleNetworksEnabled: true,
 		},
 		{
-			name:             "Input_udn_name_is_default_return_fatal_error",
-			dirName:          "udn_bad_path_test_4",
-			errorStrContains: alerts.UDNNameAssertion("blue/default"),
+			name:                    "Input_udn_name_is_default_return_fatal_error",
+			dirName:                 "udn_bad_path_test_4",
+			errorStrContains:        alerts.UDNNameAssertion("blue/default"),
+			multipleNetworksEnabled: true,
 		},
 		{
-			name:             "Input_udn_is_in_default_namespace_return_fatal_error",
-			dirName:          "udn_bad_path_test_5",
-			errorStrContains: alerts.UDNNamespaceAssertion("namespace-scoped", "default"),
+			name:                    "Input_udn_is_in_default_namespace_return_fatal_error",
+			dirName:                 "udn_bad_path_test_5",
+			errorStrContains:        alerts.UDNNamespaceAssertion("namespace-scoped", "default"),
+			multipleNetworksEnabled: true,
 		},
 		{
-			name:             "Input_udn_is_in_openshift_namespace_return_fatal_error",
-			dirName:          "udn_bad_path_test_6",
-			errorStrContains: alerts.UDNNamespaceAssertion("namespace-scoped", "openshift-oc"),
+			name:                    "Input_udn_is_in_openshift_namespace_return_fatal_error",
+			dirName:                 "udn_bad_path_test_6",
+			errorStrContains:        alerts.UDNNamespaceAssertion("namespace-scoped", "openshift-oc"),
+			multipleNetworksEnabled: true,
 		},
 		{
-			name:             "Input_namespace_has_two_primary_UDNs_return_fatal_error",
-			dirName:          "udn_bad_path_test_7",
-			errorStrContains: alerts.OnePrimaryUDNAssertion("blue", "blue/separate-namespace", "blue/namespace-scoped"),
+			name:                    "Input_namespace_has_two_primary_UDNs_return_fatal_error",
+			dirName:                 "udn_bad_path_test_7",
+			errorStrContains:        alerts.OnePrimaryUDNAssertion("blue", "blue/separate-namespace", "blue/namespace-scoped"),
+			multipleNetworksEnabled: true,
 		},
 		{
-			name:             "Input_namespace_selected_by_two_primary_CUDN_and_UDN_return_fatal_error",
-			dirName:          "cudn_bad_test_1",
-			errorStrContains: alerts.OnePrimaryUDNAssertion("red", "cudn-selecting-red-ns", "red/red-network"),
+			name:                    "Input_namespace_selected_by_two_primary_CUDN_and_UDN_return_fatal_error",
+			dirName:                 "cudn_bad_test_1",
+			errorStrContains:        alerts.OnePrimaryUDNAssertion("red", "cudn-selecting-red-ns", "red/red-network"),
+			multipleNetworksEnabled: true,
 		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			for _, apiToTest := range connlistTestedAPIS {
-				analyzer, connsRes, peersRes, err := getAnalysisResFromAPI(apiToTest, tt.dirName, nil, nil, "")
+				analyzer, connsRes, peersRes, err := getAnalysisResFromAPI(apiToTest, tt.dirName, nil, nil, "", tt.multipleNetworksEnabled)
 				testFatalErr(t, connsRes, peersRes, err, tt.name, tt.errorStrContains, analyzer)
 			}
 		})
@@ -443,9 +452,10 @@ func testFatalErr(t *testing.T,
 	testutils.CheckErrorContainment(t, testName, errStr, analyzer.errors[0].Error().Error())
 }
 
-func getAnalysisResFromAPI(apiName, dirName string, focusWorkloads, focusWorkloadPeers []string, focusDirection string) (
+func getAnalysisResFromAPI(apiName, dirName string, focusWorkloads, focusWorkloadPeers []string, focusDirection string,
+	multipleNetworks bool) (
 	analyzer *ConnlistAnalyzer, connsRes []Peer2PeerConnection, peersRes []Peer, err error) {
-	pTest := prepareTest(dirName, focusWorkloads, focusWorkloadPeers, focusDirection, "", output.DefaultFormat, false)
+	pTest := prepareTest(dirName, focusWorkloads, focusWorkloadPeers, focusDirection, "", output.DefaultFormat, false, multipleNetworks)
 	switch apiName {
 	case ResourceInfosFunc:
 		infos, _ := fsscanner.GetResourceInfosFromDirPath([]string{pTest.dirPath}, true, false)
@@ -578,7 +588,7 @@ func TestConnlistAnalyzeSevereErrorsAndWarnings(t *testing.T) {
 
 			for _, apiToTest := range connlistTestedAPIS {
 				analyzer, connsRes, peersRes, err := getAnalysisResFromAPI(apiToTest, tt.dirName, tt.focusWorkloads,
-					tt.focusWorkloadPeers, tt.focusDirection)
+					tt.focusWorkloadPeers, tt.focusDirection, false)
 				require.Nil(t, err, tt.name)
 				if tt.emptyRes {
 					require.Empty(t, connsRes, tt.name)
@@ -642,7 +652,7 @@ func TestFatalErrorsConnlistFromDirPathOnly(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			analyzer, connsRes, peersRes, err := getAnalysisResFromAPI(DirPathFunc, tt.dirName, nil, nil, "")
+			analyzer, connsRes, peersRes, err := getAnalysisResFromAPI(DirPathFunc, tt.dirName, nil, nil, "", false)
 			testFatalErr(t, connsRes, peersRes, err, tt.name, tt.errorStrContains, analyzer)
 		})
 	}
@@ -673,7 +683,7 @@ func TestErrorsAndWarningsConnlistFromDirPathOnly(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			analyzer, connsRes, peersRes, err := getAnalysisResFromAPI(DirPathFunc, tt.dirName, nil, nil, "")
+			analyzer, connsRes, peersRes, err := getAnalysisResFromAPI(DirPathFunc, tt.dirName, nil, nil, "", false)
 			require.Nil(t, err, tt.name)
 			if tt.emptyRes {
 				require.Empty(t, connsRes, tt.name)
@@ -700,6 +710,7 @@ func TestLoggerWarnings(t *testing.T) {
 		explain                     bool
 		explainOnly                 string
 		expectedWarningsStrContains []string
+		multipleNetworksEnabled     bool
 	}{
 		{
 			name:                        "input_admin_policy_contains_nodes_egress_peer_should_get_warning",
@@ -768,31 +779,43 @@ func TestLoggerWarnings(t *testing.T) {
 			name:                        "using_secondary_udn_should_warn_that_not_supported_yet",
 			dirName:                     "udn_warning_test_1",
 			expectedWarningsStrContains: []string{alerts.NotSupportedUDNRole("green/namespace-scoped")},
+			multipleNetworksEnabled:     true,
 		},
 		{
 			name:                        "udn_in_not_existing_namespace_should_warn_that_udn_is_ignored",
 			dirName:                     "udn_warning_test_2",
 			expectedWarningsStrContains: []string{alerts.WarnMissingNamespaceOfUDN("separate-namespace", "blue")},
+			multipleNetworksEnabled:     true,
 		},
 		{
 			name:                        "udn_in_ns_without_label_should_warn_that_udn_is_ignored",
 			dirName:                     "udn_warning_test_3",
 			expectedWarningsStrContains: []string{alerts.WarnNamespaceDoesNotSupportUDN("namespace-scoped", "green")},
+			multipleNetworksEnabled:     true,
 		},
 		{
 			name:                        "input_resources_contain_virt_launcher_pod_should_warn_that_it_is_ignored",
 			dirName:                     "udn_and_vms_test_5",
 			expectedWarningsStrContains: []string{alerts.WarnIgnoredVirtLauncherPod("foo/virt-launcher-fedora-apricot-pike-81-qr48r")},
+			multipleNetworksEnabled:     true,
 		},
 		{
 			name:                        "cudn_selecting_a_ns_without_label_should_warn_that_selection_is_ignored",
 			dirName:                     "cudn_test_3",
 			expectedWarningsStrContains: []string{alerts.WarnCudnSelectsNsWithoutPrimaryUDNLabel("entire-cluster-cudn", "yellow-namespace")},
+			multipleNetworksEnabled:     true,
 		},
 		{
 			name:                        "cudn_selector_has_no_matches",
 			dirName:                     "cudn_warning_test_1",
 			expectedWarningsStrContains: []string{alerts.EmptyCUDN("no-selection")},
+			multipleNetworksEnabled:     true,
+		},
+		{
+			name:                        "nad_is_ignored_if_multiple_networks_is_disabled",
+			dirName:                     "nad_test_1",
+			expectedWarningsStrContains: []string{"skipping object with type: NetworkAttachmentDefinition"},
+			multipleNetworksEnabled:     false,
 		},
 	}
 	for _, tt := range cases {
@@ -806,6 +829,9 @@ func TestLoggerWarnings(t *testing.T) {
 			}
 			if tt.explain {
 				opts = append(opts, WithExplanation())
+			}
+			if tt.multipleNetworksEnabled {
+				opts = append(opts, WithMultipleNetworks())
 			}
 			_, _, err := getConnlistFromDirPathRes(opts, tt.dirName)
 			require.Nil(t, err, "test: %q", tt.name)
@@ -885,7 +911,7 @@ type preparedTest struct {
 }
 
 func prepareTest(dirName string, focusWorkloads, focusWorkloadPeers []string, focusDirection, focusConn, format string,
-	exposureFlag bool) preparedTest {
+	exposureFlag, multipleNetworksEnabled bool) preparedTest {
 	res := preparedTest{}
 	res.testName, res.expectedOutputFileName = testutils.ConnlistTestNameByTestArgs(dirName,
 		strings.Join(focusWorkloads, testutils.Underscore),
@@ -895,6 +921,9 @@ func prepareTest(dirName string, focusWorkloads, focusWorkloadPeers []string, fo
 		WithFocusWorkloadPeerList(focusWorkloadPeers), WithFocusConnection(focusConn)}
 	if exposureFlag {
 		opts = append(opts, WithExposureAnalysis())
+	}
+	if multipleNetworksEnabled {
+		opts = append(opts, WithMultipleNetworks())
 	}
 	res.analyzer = NewConnlistAnalyzer(opts...)
 	res.dirPath = testutils.GetTestDirPath(dirName)
@@ -931,7 +960,7 @@ func TestConnlistOutputFatalErrors(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			preparedTest := prepareTest(tt.dirName, nil, nil, "", "", tt.format, tt.exposureFlag)
+			preparedTest := prepareTest(tt.dirName, nil, nil, "", "", tt.format, tt.exposureFlag, false)
 			connsRes, peersRes, err := preparedTest.analyzer.ConnlistFromDirPath(preparedTest.dirPath)
 
 			require.Nil(t, err, tt.name)
@@ -945,7 +974,7 @@ func TestConnlistOutputFatalErrors(t *testing.T) {
 			testutils.CheckErrorContainment(t, tt.name, tt.errorStrContains, err.Error())
 
 			// re-run the test with new analyzer (to clear the analyzer.errors array )
-			preparedTest = prepareTest(tt.dirName, nil, nil, "", "", tt.format, tt.exposureFlag)
+			preparedTest = prepareTest(tt.dirName, nil, nil, "", "", tt.format, tt.exposureFlag, false)
 			infos, _ := fsscanner.GetResourceInfosFromDirPath([]string{preparedTest.dirPath}, true, false)
 			connsRes2, peersRes2, err2 := preparedTest.analyzer.ConnlistFromResourceInfos(infos)
 
@@ -962,14 +991,15 @@ func TestConnlistOutputFatalErrors(t *testing.T) {
 }
 
 var goodPathTests = []struct {
-	testDirName            string
-	outputFormats          []string
-	focusWorkloads         []string
-	focusWorkloadPeers     []string
-	focusDirection         string
-	focusConn              string
-	exposureAnalysis       bool
-	supportedOnLiveCluster bool
+	testDirName             string
+	outputFormats           []string
+	focusWorkloads          []string
+	focusWorkloadPeers      []string
+	focusDirection          string
+	focusConn               string
+	exposureAnalysis        bool
+	multipleNetworksEnabled bool
+	supportedOnLiveCluster  bool
 }{
 	{
 		testDirName:            "ipblockstest",
@@ -2145,108 +2175,128 @@ var goodPathTests = []struct {
 	{
 		// With user-defined networks, the need for complex network policies are eliminated because isolation
 		// can be achieved by grouping workloads in different networks.
-		testDirName:   "udn_test_1",
-		outputFormats: ValidFormats,
+		testDirName:             "udn_test_1",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
 		// user-defined network with network-policy in an isolated network
-		testDirName:   "udn_test_2",
-		outputFormats: ValidFormats,
+		testDirName:             "udn_test_2",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
 		// user-defined network with network-policy in an isolated network
-		testDirName:   "udn_test_2",
-		outputFormats: ValidFormats,
-		focusConn:     "tcp-90",
+		testDirName:             "udn_test_2",
+		outputFormats:           ValidFormats,
+		focusConn:               "tcp-90",
+		multipleNetworksEnabled: true,
 	},
 	{
 		// one user-defined network with network-policy.
 		// 2 regular pod networks (in namespaces without UDN)
 		// AdminNetworkPolicy that enables egress from pods with specific label - pods in the udn still isolated
-		testDirName:   "udn_test_3",
-		outputFormats: ValidFormats,
+		testDirName:             "udn_test_3",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
 		// one user-defined network with network-policy.
 		// 2 namespaces in regular pod networks (without UDN)
 		// Networkpolicy in the regular pod networks that enables egress to whole world - pods in the udn still isolated
-		testDirName:   "udn_test_4",
-		outputFormats: ValidFormats,
+		testDirName:             "udn_test_4",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
 		// a test with UDN and Ingress-Controller; external ingress to a service in a UDN are allowed if the pod's ports match
-		testDirName:   "udn_with_ingress_controller",
-		outputFormats: ValidFormats,
+		testDirName:             "udn_with_ingress_controller",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
 		// a test with UDN and Ingress-Controller; external ingress to a service in a UDN are allowed if the pod's ports match
 		// this test contains two pods in the UDN, one matches the Ingress and service's ports and the second not matching them
-		testDirName:   "udn_with_ingress_controller_two_pods",
-		outputFormats: ValidFormats,
+		testDirName:             "udn_with_ingress_controller_two_pods",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	// tests involving udn(s) and virtual-machine workloads
 	{
-		testDirName:   "udn_and_vms_test_1",
-		outputFormats: ValidFormats,
+		testDirName:             "udn_and_vms_test_1",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName:   "udn_and_vms_test_2",
-		outputFormats: ValidFormats,
+		testDirName:             "udn_and_vms_test_2",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName:   "udn_and_vms_test_3",
-		outputFormats: ValidFormats,
+		testDirName:             "udn_and_vms_test_3",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName:   "udn_and_vms_test_4",
-		outputFormats: ValidFormats,
+		testDirName:             "udn_and_vms_test_4",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName:   "udn_and_vms_test_5",
-		outputFormats: ValidFormats,
+		testDirName:             "udn_and_vms_test_5",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
 		// virtual-machine(s) test in the default namespace (without-udn)
-		testDirName:   "virtual_machines_example",
-		outputFormats: ValidFormats,
+		testDirName:             "virtual_machines_example",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
 		// a test with UDN having a VM and Ingress-Controller; external ingress ports to a service in a UDN are allowed to the VM
-		testDirName:   "udn_with_vm_and_ingress_controller",
-		outputFormats: ValidFormats,
+		testDirName:             "udn_with_vm_and_ingress_controller",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
 		// resource: https://github.com/maiqueb/fosdem2025-p-udn/tree/main/manifests/cluster-wide-network
-		testDirName:   "cudn_test_1",
-		outputFormats: ValidFormats,
+		testDirName:             "cudn_test_1",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
 		// cudn selects all namespaces, all of them have the required label to define ns as a udn
-		testDirName:   "cudn_test_2",
-		outputFormats: ValidFormats,
+		testDirName:             "cudn_test_2",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
 		// cudn selects all namespaces, but not all of the namespaces has the required label in their spec,
 		// so those will not belong to the cudn
-		testDirName:   "cudn_test_3",
-		outputFormats: ValidFormats,
+		testDirName:             "cudn_test_3",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
 		// resource: https://github.com/epheo/blog/tree/e0e83c121b6b225fd38c6443bf19b7b5a0f7687d/articles/openshift-layer2-udn
 		// involves udn and cudn
-		testDirName:   "cudn_test_4",
-		outputFormats: ValidFormats,
+		testDirName:             "cudn_test_4",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
 		// resource: https://github.com/tssurya/kubecon-eu-2025-london-udn-workshop/tree
 		// /4d6be99a0ee1ede775a505c35026ee75c799228d/manifests/udns-with-pods
 		// cudn + udns + networkpolicy
-		testDirName:   "cudn_test_5",
-		outputFormats: ValidFormats,
+		testDirName:             "cudn_test_5",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName:   "cudn_test_6",
-		outputFormats: ValidFormats,
+		testDirName:             "cudn_test_6",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
 		//  this example is taken from :
@@ -2254,96 +2304,110 @@ var goodPathTests = []struct {
 		//  quote from the link above that demonstrates connectivity:
 		//  In it, the pod network is used to access the outside world (e.g., the Internet) and Kubernetes services,
 		//  while the secondary network is used for communication between the VMs
-		testDirName:   "nad_test_2",
-		outputFormats: ValidFormats,
+		testDirName:             "nad_test_2",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName:   "nad_test_1",
-		outputFormats: ValidFormats,
+		testDirName:             "nad_test_1",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName:   "nad_test_2",
-		outputFormats: ValidFormats,
-		focusConn:     "tcp-80",
+		testDirName:             "nad_test_2",
+		outputFormats:           ValidFormats,
+		focusConn:               "tcp-80",
+		multipleNetworksEnabled: true,
 	},
 	{
 		// 2 vm from different namespaces belong to same secondary network with 2 multi-network-policy defining how both can connect
-		testDirName:   "nad_test_3",
-		outputFormats: ValidFormats,
+		testDirName:             "nad_test_3",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
 		// same as nad_test_3 with networkpolicies deniying all conns in the pod-network
-		testDirName:   "nad_test_4",
-		outputFormats: ValidFormats,
+		testDirName:             "nad_test_4",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
 		// same as nad_test_3 with networkpolicies deniying all conns in the pod-network
-		testDirName:    "nad_test_4",
-		outputFormats:  ValidFormats,
-		focusConn:      "tcp-80",
-		focusDirection: common.IngressFocusDirection,
+		testDirName:             "nad_test_4",
+		outputFormats:           ValidFormats,
+		focusConn:               "tcp-80",
+		focusDirection:          common.IngressFocusDirection,
+		multipleNetworksEnabled: true,
 	},
 	{
 		// same as nad_test_3 with networkpolicies deniying all conns in the pod-network
-		testDirName:        "nad_test_4",
-		outputFormats:      ValidFormats,
-		focusConn:          "tcp-80",
-		focusDirection:     common.IngressFocusDirection,
-		focusWorkloads:     []string{"pod2"},
-		focusWorkloadPeers: []string{"pod3"},
+		testDirName:             "nad_test_4",
+		outputFormats:           ValidFormats,
+		focusConn:               "tcp-80",
+		focusDirection:          common.IngressFocusDirection,
+		focusWorkloads:          []string{"pod2"},
+		focusWorkloadPeers:      []string{"pod3"},
+		multipleNetworksEnabled: true,
 	},
 	{
 		// test is taken from :
 		// https://github.com/openshift/multus-networkpolicy/blob/278ec20e795c3a590500e789716be7fcc4d7107b/e2e/tests/simple-v4-egress.yml#L28
 		// added default deny networkpolicy to restrict connections with external ip-blocks in the pod-network
-		testDirName:   "nad_test_5",
-		outputFormats: ValidFormats,
+		testDirName:             "nad_test_5",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
 		// test is taken from :
 		// https://github.com/openshift/multus-networkpolicy/blob/278ec20e795c3a590500e789716be7fcc4d7107b/e2e/tests/simple-v4-ingress.yml
 		// added default deny networkpolicy to restrict connections with external ip-blocks in the pod-network
-		testDirName:   "nad_test_6",
-		outputFormats: ValidFormats,
+		testDirName:             "nad_test_6",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
 		// test is taken from :
 		// https://github.com/openshift/multus-networkpolicy/blob/278ec20e795c3a590500e789716be7fcc4d7107b/e2e/tests/ingress-ns-selector-
 		// no-pods.yml
 		// added default deny networkpolicy to restrict connections with external ip-blocks in the pod-network
-		testDirName:    "nad_test_7",
-		outputFormats:  ValidFormats,
-		focusWorkloads: []string{"pod-server"},
+		testDirName:             "nad_test_7",
+		outputFormats:           ValidFormats,
+		focusWorkloads:          []string{"pod-server"},
+		multipleNetworksEnabled: true,
 	},
 	{
 		// test is taken from :
 		// https://github.com/openshift/multus-networkpolicy/blob/278ec20e795c3a590500e789716be7fcc4d7107b/e2e/tests/protocol-only-ports.yml
 		// added default deny networkpolicy to restrict connections with external ip-blocks in the pod-network
-		testDirName:   "nad_test_8",
-		outputFormats: ValidFormats,
+		testDirName:             "nad_test_8",
+		outputFormats:           ValidFormats,
+		multipleNetworksEnabled: true,
 	},
 	{
 		// test is taken from :
 		// https://github.com/openshift/multus-networkpolicy/blob/278ec20e795c3a590500e789716be7fcc4d7107b/e2e/tests/simple-v4-egress-list.yml
 		// added default deny networkpolicy to restrict connections with external ip-blocks in the pod-network
-		testDirName:    "nad_test_9",
-		outputFormats:  []string{output.SVGFormat, output.DOTFormat, output.TextFormat},
-		focusWorkloads: []string{"pod-server"},
+		testDirName:             "nad_test_9",
+		outputFormats:           []string{output.SVGFormat, output.DOTFormat, output.TextFormat},
+		focusWorkloads:          []string{"pod-server"},
+		multipleNetworksEnabled: true,
 	},
 	{
 		// test is taken from :
 		// https://github.com/openshift/multus-networkpolicy/blob/278ec20e795c3a590500e789716be7fcc4d7107b/e2e/tests/simple-v4-ingress-list.yml
-		testDirName:    "nad_test_10",
-		outputFormats:  []string{output.SVGFormat, output.DOTFormat, output.TextFormat},
-		focusWorkloads: []string{"pod-server"}, // connects with external ips by pod-network, no restriction
+		testDirName:             "nad_test_10",
+		outputFormats:           []string{output.SVGFormat, output.DOTFormat, output.TextFormat},
+		focusWorkloads:          []string{"pod-server"}, // connects with external ips by pod-network, no restriction
+		multipleNetworksEnabled: true,
 	},
 	{
 		// test is taken from :
 		// https://github.com/openshift/multus-networkpolicy/blob/278ec20e795c3a590500e789716be7fcc4d7107b/e2e/tests/stacked.yml
 		// added default deny networkpolicy to restrict connections with external ip-blocks in the pod-network
-		testDirName:    "nad_test_11",
-		outputFormats:  []string{output.SVGFormat, output.DOTFormat, output.TextFormat},
-		focusWorkloads: []string{"pod-server"},
+		testDirName:             "nad_test_11",
+		outputFormats:           []string{output.SVGFormat, output.DOTFormat, output.TextFormat},
+		focusWorkloads:          []string{"pod-server"},
+		multipleNetworksEnabled: true,
 	},
 	{
 		// two namespaces , each is a primary udn assigned;
@@ -2351,22 +2415,25 @@ var goodPathTests = []struct {
 		// even though all pods and vm-s share same secondary network;
 		// since allowed-conns between two peers is returned in one-network only (one *connectionSet for each pair)
 		// and the primary interface of each peer takes precedence on all other networks.
-		testDirName:   "nad_test_12",
-		outputFormats: []string{output.SVGFormat, output.DOTFormat, output.TextFormat},
+		testDirName:             "nad_test_12",
+		outputFormats:           []string{output.SVGFormat, output.DOTFormat, output.TextFormat},
+		multipleNetworksEnabled: true,
 	},
 	{
 		// same udn networks from nad_test_12 with new added two regular namespaces (with no udn): ns-c, ns-d
 		// all pods in ns-c and ns-d are sharing same secondary network interface;
 		// then we will see connections between peers from those namespaces in the shared network
-		testDirName:   "nad_test_13",
-		outputFormats: []string{output.SVGFormat, output.DOTFormat, output.TextFormat},
+		testDirName:             "nad_test_13",
+		outputFormats:           []string{output.SVGFormat, output.DOTFormat, output.TextFormat},
+		multipleNetworksEnabled: true,
 	},
 	{
 		// same objects from nad_test_13, with network-policy and multi-network-policy objects;
 		// to see that network-policy objects affect connectivity in pod-network and UDN networks only
 		// while multi-netpol objects affects connectivity in secondary networks only
-		testDirName:   "nad_test_14",
-		outputFormats: []string{output.SVGFormat, output.DOTFormat, output.TextFormat},
+		testDirName:             "nad_test_14",
+		outputFormats:           []string{output.SVGFormat, output.DOTFormat, output.TextFormat},
+		multipleNetworksEnabled: true,
 	},
 }
 

--- a/pkg/netpol/connlist/explanation_test.go
+++ b/pkg/netpol/connlist/explanation_test.go
@@ -25,7 +25,7 @@ func TestExplainFromDir(t *testing.T) {
 		t.Run(tt.testDirName, func(t *testing.T) {
 			t.Parallel()
 			pTest := prepareExplainTest(tt.testDirName, tt.focusWorkloads, tt.focusWorkloadPeers, tt.focusDirection,
-				tt.focusConn, tt.explainOnly, tt.exposure)
+				tt.focusConn, tt.explainOnly, tt.exposure, tt.multipleNetworksEnabled)
 			res, _, err := pTest.analyzer.ConnlistFromDirPath(pTest.dirPath)
 			require.Nil(t, err, pTest.testInfo)
 			out, err := pTest.analyzer.ConnectionsListToString(res)
@@ -37,7 +37,7 @@ func TestExplainFromDir(t *testing.T) {
 }
 
 func prepareExplainTest(dirName string, focusWorkloads, focusWorkloadPeers []string, focusDirection, focusConn,
-	explainOnly string, exposure bool) preparedTest {
+	explainOnly string, exposure, multipleNetworksEnabled bool) preparedTest {
 	res := preparedTest{}
 	res.testName, res.expectedOutputFileName = testutils.ExplainTestNameByTestArgs(dirName,
 		strings.Join(focusWorkloads, testutils.Underscore), strings.Join(focusWorkloadPeers, testutils.Underscore), focusDirection,
@@ -49,20 +49,24 @@ func prepareExplainTest(dirName string, focusWorkloads, focusWorkloadPeers []str
 	if exposure {
 		opts = append(opts, WithExposureAnalysis())
 	}
+	if multipleNetworksEnabled {
+		opts = append(opts, WithMultipleNetworks())
+	}
 	res.analyzer = NewConnlistAnalyzer(opts...)
 	res.dirPath = testutils.GetTestDirPath(dirName)
 	return res
 }
 
 var explainTests = []struct {
-	testDirName            string
-	focusWorkloads         []string
-	focusDirection         string
-	focusConn              string
-	focusWorkloadPeers     []string
-	exposure               bool
-	explainOnly            string
-	supportedOnLiveCluster bool
+	testDirName             string
+	focusWorkloads          []string
+	focusDirection          string
+	focusConn               string
+	focusWorkloadPeers      []string
+	exposure                bool
+	explainOnly             string
+	supportedOnLiveCluster  bool
+	multipleNetworksEnabled bool
 }{
 	{
 		testDirName: "netpol-demo",
@@ -319,70 +323,88 @@ var explainTests = []struct {
 		exposure:    true,
 	},
 	{
-		testDirName: "udn_test_1",
+		testDirName:             "udn_test_1",
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName: "udn_test_2",
+		testDirName:             "udn_test_2",
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName: "udn_test_3",
+		testDirName:             "udn_test_3",
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName: "udn_test_4",
+		testDirName:             "udn_test_4",
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName: "udn_test_4",
-		focusConn:   "tcp-8080",
+		testDirName:             "udn_test_4",
+		focusConn:               "tcp-8080",
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName: "udn_test_1",
-		focusConn:   "tcp-90",
+		testDirName:             "udn_test_1",
+		focusConn:               "tcp-90",
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName: "virtual_machines_example",
+		testDirName:             "virtual_machines_example",
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName: "udn_and_vms_test_4",
+		testDirName:             "udn_and_vms_test_4",
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName: "udn_and_vms_test_5",
+		testDirName:             "udn_and_vms_test_5",
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName: "cudn_test_1",
+		testDirName:             "cudn_test_1",
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName: "cudn_test_6",
+		testDirName:             "cudn_test_6",
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName:    "cudn_test_6",
-		focusWorkloads: []string{"app-yellow"},
+		testDirName:             "cudn_test_6",
+		focusWorkloads:          []string{"app-yellow"},
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName:    "cudn_test_6",
-		focusWorkloads: []string{"app-green"},
-		focusConn:      "tcp-8000",
+		testDirName:             "cudn_test_6",
+		focusWorkloads:          []string{"app-green"},
+		focusConn:               "tcp-8000",
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName: "nad_test_3",
+		testDirName:             "nad_test_3",
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName: "nad_test_4",
+		testDirName:             "nad_test_4",
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName:    "nad_test_4",
-		focusConn:      "tcp-80",
-		focusDirection: common.IngressFocusDirection,
+		testDirName:             "nad_test_4",
+		focusConn:               "tcp-80",
+		focusDirection:          common.IngressFocusDirection,
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName:        "nad_test_4",
-		focusConn:          "tcp-80",
-		focusDirection:     common.IngressFocusDirection,
-		focusWorkloads:     []string{"pod2"},
-		focusWorkloadPeers: []string{"pod3"},
+		testDirName:             "nad_test_4",
+		focusConn:               "tcp-80",
+		focusDirection:          common.IngressFocusDirection,
+		focusWorkloads:          []string{"pod2"},
+		focusWorkloadPeers:      []string{"pod3"},
+		multipleNetworksEnabled: true,
 	},
 	{
-		testDirName: "nad_test_4",
-		focusConn:   "tcp-80",
-		explainOnly: common.ExplainOnlyAllow,
+		testDirName:             "nad_test_4",
+		focusConn:               "tcp-80",
+		explainOnly:             common.ExplainOnlyAllow,
+		multipleNetworksEnabled: true,
 	},
 }

--- a/pkg/netpol/connlist/internal/ingressanalyzer/ingress_analyzer_test.go
+++ b/pkg/netpol/connlist/internal/ingressanalyzer/ingress_analyzer_test.go
@@ -26,7 +26,7 @@ var l = logger.NewDefaultLogger()
 func getIngressAnalyzerFromDirObjects(t *testing.T, testName, dirName string, processingErrsNum int) *IngressAnalyzer {
 	path := testutils.GetTestDirPath(dirName)
 	rList, _ := fsscanner.GetResourceInfosFromDirPath([]string{path}, true, false)
-	objects, fpErrs := parser.ResourceInfoListToK8sObjectsList(rList, l, false)
+	objects, fpErrs := parser.ResourceInfoListToK8sObjectsList(rList, l, false, false)
 	require.Len(t, fpErrs, processingErrsNum, "test: %q, expected %d processing errors but got %d",
 		testName, processingErrsNum, len(fpErrs))
 	pe, err := eval.NewPolicyEngineWithOptionsList(eval.WithObjectsList(objects))

--- a/pkg/netpol/connlist/internal/ingressanalyzer/service_test.go
+++ b/pkg/netpol/connlist/internal/ingressanalyzer/service_test.go
@@ -85,7 +85,7 @@ func TestServiceMappingToPods(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			rList, _ := fsscanner.GetResourceInfosFromDirPath([]string{servicesDir}, true, false)
-			objects, processingErrs := parser.ResourceInfoListToK8sObjectsList(rList, l, false)
+			objects, processingErrs := parser.ResourceInfoListToK8sObjectsList(rList, l, false, false)
 			require.Len(t, processingErrs, 1, "test: %q", tt.name) // no policies
 			require.Len(t, objects, 17, "test: %q", tt.name)       // found 6 services and 11 pods
 			pe, err := eval.NewPolicyEngineWithOptionsList(eval.WithObjectsList(objects))

--- a/pkg/netpol/diff/diff.go
+++ b/pkg/netpol/diff/diff.go
@@ -196,10 +196,14 @@ func (da *DiffAnalyzer) getConnlistAnalysis(
 // return a []ConnlistAnalyzerOption with mute errs/warns, so that logging of err/wanr is not duplicated, and
 // added to log only by getConnlistAnalysis function, which adds the context of ref1/ref2
 func (da *DiffAnalyzer) determineConnlistAnalyzerOptions() []connlist.ConnlistAnalyzerOption {
+	opts := []connlist.ConnlistAnalyzerOption{connlist.WithMuteErrsAndWarns(), connlist.WithLogger(da.logger)}
 	if da.stopOnError {
-		return []connlist.ConnlistAnalyzerOption{connlist.WithMuteErrsAndWarns(), connlist.WithLogger(da.logger), connlist.WithStopOnError()}
+		opts = append(opts, connlist.WithStopOnError())
 	}
-	return []connlist.ConnlistAnalyzerOption{connlist.WithMuteErrsAndWarns(), connlist.WithLogger(da.logger)}
+	if da.multipleNetworks {
+		opts = append(opts, connlist.WithMultipleNetworks())
+	}
+	return opts
 }
 
 func (da *DiffAnalyzer) errPrefixSpecifyRefName(isRef1 bool) string {

--- a/pkg/netpol/diff/diff_analyzer.go
+++ b/pkg/netpol/diff/diff_analyzer.go
@@ -14,12 +14,13 @@ import (
 // A DiffAnalyzer provides API to recursively scan two directories for Kubernetes resources including network policies,
 // and get the difference of permitted connectivity between the workloads of the K8s application managed in theses directories.
 type DiffAnalyzer struct {
-	logger       logger.Logger
-	stopOnError  bool
-	errors       []DiffError
-	outputFormat string
-	ref1Name     string
-	ref2Name     string
+	logger           logger.Logger
+	stopOnError      bool
+	errors           []DiffError
+	outputFormat     string
+	ref1Name         string
+	ref2Name         string
+	multipleNetworks bool
 }
 
 // DiffAnalyzerOption is the type for specifying options for DiffAnalyzer,
@@ -49,6 +50,14 @@ func WithStopOnError() DiffAnalyzerOption {
 	}
 }
 
+// WithMultipleNetworks is a functional option which directs DiffAnalyzer to enable parsing and analyzing multiple-networks resources,
+// such as (Cluster)UserDefinedNetwork, NetworkAttachmentDefinition and MultiNetworkPolicy
+func WithMultipleNetworks() DiffAnalyzerOption {
+	return func(da *DiffAnalyzer) {
+		da.multipleNetworks = true
+	}
+}
+
 // WithArgNames is a functional option that sets the names to be used for the two sets of analyzed resources
 // (default is ref1,ref2) in the output reports and log messages.
 func WithArgNames(ref1Name, ref2Name string) DiffAnalyzerOption {
@@ -67,12 +76,13 @@ func (da *DiffAnalyzer) Errors() []DiffError {
 func NewDiffAnalyzer(options ...DiffAnalyzerOption) *DiffAnalyzer {
 	// object with default behavior options
 	da := &DiffAnalyzer{
-		logger:       logger.NewDefaultLogger(),
-		stopOnError:  false,
-		errors:       []DiffError{},
-		outputFormat: output.DefaultFormat,
-		ref1Name:     "ref1",
-		ref2Name:     "ref2",
+		logger:           logger.NewDefaultLogger(),
+		stopOnError:      false,
+		errors:           []DiffError{},
+		outputFormat:     output.DefaultFormat,
+		ref1Name:         "ref1",
+		ref2Name:         "ref2",
+		multipleNetworks: false,
 	}
 	for _, o := range options {
 		o(da)

--- a/pkg/netpol/eval/eval_test.go
+++ b/pkg/netpol/eval/eval_test.go
@@ -1057,7 +1057,7 @@ func writeRes(res, fileName string) {
 
 func setResourcesFromDir(pe *PolicyEngine, path string, netpolLimit ...int) error {
 	rList, _ := fsscanner.GetResourceInfosFromDirPath([]string{path}, true, false)
-	objectsList, processingErrs := parser.ResourceInfoListToK8sObjectsList(rList, logger.NewDefaultLogger(), false)
+	objectsList, processingErrs := parser.ResourceInfoListToK8sObjectsList(rList, logger.NewDefaultLogger(), false, false)
 	if len(processingErrs) > 0 {
 		return errors.New("processing errors occurred")
 	}
@@ -1782,7 +1782,7 @@ func TestPolicyEngineWithWorkloads(t *testing.T) {
 	path := testutils.GetTestDirPath("onlineboutique_workloads")
 
 	rList, _ := fsscanner.GetResourceInfosFromDirPath([]string{path}, true, false)
-	objects, processingErrs := parser.ResourceInfoListToK8sObjectsList(rList, logger.NewDefaultLogger(), false)
+	objects, processingErrs := parser.ResourceInfoListToK8sObjectsList(rList, logger.NewDefaultLogger(), false, false)
 	if len(processingErrs) > 0 {
 		t.Fatalf("TestPolicyEngineWithWorkloads errors: %v", processingErrs)
 	}
@@ -1956,7 +1956,7 @@ func TestDirPathEvalResults(t *testing.T) {
 			path := testutils.GetTestDirPath(tt.dir)
 			rList, errs := fsscanner.GetResourceInfosFromDirPath([]string{path}, true, false)
 			require.Empty(t, errs, "test: %q", testName)
-			objectsList, processingErrs := parser.ResourceInfoListToK8sObjectsList(rList, logger.NewDefaultLogger(), false)
+			objectsList, processingErrs := parser.ResourceInfoListToK8sObjectsList(rList, logger.NewDefaultLogger(), false, false)
 			require.Empty(t, processingErrs, "test: %q", testName)
 			pe, err := NewPolicyEngineWithOptionsList(WithObjectsList(objectsList))
 			require.Nil(t, err, "test: %q", testName)

--- a/pkg/netpol/internal/formatting/svg_output_formatting.go
+++ b/pkg/netpol/internal/formatting/svg_output_formatting.go
@@ -19,7 +19,7 @@ const graphvizSvgArgs = "-T" + output.SVGFormat
 // GenerateSVGWithGraphviz  generate svg string of the given dot string using graphviz (already validated that graphviz is installed)
 func GenerateSVGWithGraphviz(dotOutput string) (string, error) {
 	// pipe dotOutput as in `echo 'dotOutput' | dot -Tsvg` to write svg output
-	cmd := exec.Command(output.GraphvizExecutable, graphvizSvgArgs) //nolint:gosec // nosec
+	cmd := exec.Command(output.GraphvizExecutable, graphvizSvgArgs) //nolint:gosec,noctx // nosec, context is not needed here
 	cmd.Stdin = bytes.NewBufferString(dotOutput)
 	var out bytes.Buffer
 	var stderr bytes.Buffer


### PR DESCRIPTION
#615 

- **New Global Flag**
   - Flag Added: `--multiple-networks`
   - Purpose: Enables analysis of multi-network resources such as:
      *  `(Cluster)UserDefinedNetwork`
      * `NetworkAttachmentDefinition`
      * `MultiNetworkPolicy`
    - Default: true
    - Location: Added to README.md and root.go to document and register the flag.

- **Core Logic Enhancements**
   - Parser Logic Updated: 
      - Function Signature Change: `ResourceInfoListToK8sObjectsList` now accept a `multipleNetworksEnabled` boolean.
         - Behavior: If `multipleNetworksEnabled` is false, multi-network resources are skipped during parsing.

- **CLI and Analyzer Integration**
  -  CLI Options: `diff.go`, `list.go`, and `evaluate.go` now append `WithMultipleNetworks()` to their respective option lists if the flag is enabled.
  - Analyzer Structs:
     * `ConnlistAnalyzer` and `DiffAnalyzer` now include a `multipleNetworks` field.
     * Functional options `WithMultipleNetworks()` added to both analyzers.

- **Test Suite Enhancements**
   - Test Coverage:
      - Tests Updated: Many test cases now include `multipleNetworksEnabled` as a parameter.
      - Purpose: Ensures both enabled and disabled states of the feature are tested.
        Examples:
       * `TestConnlistAnalyzeFatalErrors`
       * `TestLoggerWarnings` (if the switch is off (disabled) and a dir contains resource of kind `NAD`, a message `skipping object with type: NetworkAttachmentDefinition` is printed to the logger 
       * `TestDiffAnalyzeFatalErrors`
       * `TestExplainFromDir`

- **Documentation**
   ` README.md` updated to reflect the new flag and its purpose.

 


 
