### PR TITLE
Enhance Text Output for Multi-Network Connlist Analysis

### DIFF
--- a/pkg/netpol/connlist/connlist.go
+++ b/pkg/netpol/connlist/connlist.go
@@ -523,7 +523,7 @@ func (ca *ConnlistAnalyzer) getFormatter() (connsFormatter, error) {
 	case output.JSONFormat:
 		return &formatJSON{}, nil
 	case output.TextFormat:
-		return &formatText{}, nil
+		return &formatText{multipleNetworksEnabled: ca.multipleNetworks}, nil
 	case output.DOTFormat:
 		return &formatDOT{ca.peersList}, nil
 	case output.CSVFormat:

--- a/test_outputs/connlist/cudn_test_2_connlist_output.txt
+++ b/test_outputs/connlist/cudn_test_2_connlist_output.txt
@@ -1,3 +1,5 @@
+Permitted connectivity analyzed in Pod network:
+all allowed connections utilize alternative network interfaces ((C)UDN/NAD) rather than the pod-network
 
 Permitted connectivity analyzed in primary CUDN entire-cluster-cudn:
 0.0.0.0-255.255.255.255[External] => blue-namespace/blue[VirtualMachine] : All Connections

--- a/test_outputs/connlist/cudn_test_4_connlist_output.txt
+++ b/test_outputs/connlist/cudn_test_4_connlist_output.txt
@@ -1,3 +1,5 @@
+Permitted connectivity analyzed in Pod network:
+all allowed connections utilize alternative network interfaces ((C)UDN/NAD) rather than the pod-network
 
 Permitted connectivity analyzed in primary UDN udn-example:
 0.0.0.0-255.255.255.255[External] => udn-example[udn]/example-vm[VirtualMachine] : All Connections

--- a/test_outputs/connlist/nad_test_11_focus_workload_pod-server_connlist_output.txt
+++ b/test_outputs/connlist/nad_test_11_focus_workload_pod-server_connlist_output.txt
@@ -1,3 +1,5 @@
+Permitted connectivity analyzed in Pod network:
+all allowed connections utilize alternative network interfaces ((C)UDN/NAD) rather than the pod-network
 
 Permitted connectivity analyzed in secondary NAD macvlan1-stacked:
 test-stacked/pod-client-a[Pod] => test-stacked/pod-server[Pod] : All Connections

--- a/test_outputs/connlist/nad_test_12_connlist_output.txt
+++ b/test_outputs/connlist/nad_test_12_connlist_output.txt
@@ -1,3 +1,5 @@
+Permitted connectivity analyzed in Pod network:
+all allowed connections utilize alternative network interfaces ((C)UDN/NAD) rather than the pod-network
 
 Permitted connectivity analyzed in primary UDN ns-udn-a:
 0.0.0.0-255.255.255.255[External] => ns-udn-a[udn]/pod-a[Pod] : All Connections

--- a/test_outputs/connlist/nad_test_4_connlist_output.txt
+++ b/test_outputs/connlist/nad_test_4_connlist_output.txt
@@ -1,3 +1,5 @@
+Permitted connectivity analyzed in Pod network:
+all allowed connections utilize alternative network interfaces ((C)UDN/NAD) rather than the pod-network
 
 Permitted connectivity analyzed in secondary NAD l2-network:
 ns2/pod3[Pod] => ns1/pod2[Pod] : TCP 80

--- a/test_outputs/connlist/nad_test_5_connlist_output.txt
+++ b/test_outputs/connlist/nad_test_5_connlist_output.txt
@@ -1,3 +1,5 @@
+Permitted connectivity analyzed in Pod network:
+all allowed connections utilize alternative network interfaces ((C)UDN/NAD) rather than the pod-network
 
 Permitted connectivity analyzed in secondary NAD macvlan1-simple:
 test-simple-v4-egress/pod-client-a[Pod] => test-simple-v4-egress/pod-client-b[Pod] : All Connections

--- a/test_outputs/connlist/nad_test_6_connlist_output.txt
+++ b/test_outputs/connlist/nad_test_6_connlist_output.txt
@@ -1,3 +1,5 @@
+Permitted connectivity analyzed in Pod network:
+all allowed connections utilize alternative network interfaces ((C)UDN/NAD) rather than the pod-network
 
 Permitted connectivity analyzed in secondary NAD macvlan1-simple:
 test-simple-v4-ingress/pod-client-a[Pod] => test-simple-v4-ingress/pod-client-b[Pod] : All Connections

--- a/test_outputs/connlist/nad_test_7_focus_workload_pod-server_connlist_output.txt
+++ b/test_outputs/connlist/nad_test_7_focus_workload_pod-server_connlist_output.txt
@@ -1,3 +1,5 @@
+Permitted connectivity analyzed in Pod network:
+all allowed connections utilize alternative network interfaces ((C)UDN/NAD) rather than the pod-network
 
 Permitted connectivity analyzed in secondary NAD macvlan1-simple:
 test-ingress-ns-selector-no-pods/pod-server[Pod] => test-ingress-ns-selector-no-pods-blue/pod-client-b[Pod] : All Connections

--- a/test_outputs/connlist/nad_test_8_connlist_output.txt
+++ b/test_outputs/connlist/nad_test_8_connlist_output.txt
@@ -1,3 +1,5 @@
+Permitted connectivity analyzed in Pod network:
+all allowed connections utilize alternative network interfaces ((C)UDN/NAD) rather than the pod-network
 
 Permitted connectivity analyzed in secondary NAD macvlan1-simple:
 test-protocol-only-ports/pod-a[Pod] => test-protocol-only-ports/pod-b[Pod] : TCP 1-65535

--- a/test_outputs/connlist/nad_test_9_focus_workload_pod-server_connlist_output.txt
+++ b/test_outputs/connlist/nad_test_9_focus_workload_pod-server_connlist_output.txt
@@ -1,3 +1,5 @@
+Permitted connectivity analyzed in Pod network:
+all allowed connections utilize alternative network interfaces ((C)UDN/NAD) rather than the pod-network
 
 Permitted connectivity analyzed in secondary NAD macvlan1-simple:
 test-simple-v4-egress-list/pod-client-a[Pod] => test-simple-v4-egress-list/pod-server[Pod] : All Connections

--- a/test_outputs/connlist/udn_and_vms_test_1_connlist_output.txt
+++ b/test_outputs/connlist/udn_and_vms_test_1_connlist_output.txt
@@ -1,3 +1,5 @@
+Permitted connectivity analyzed in Pod network:
+all allowed connections utilize alternative network interfaces ((C)UDN/NAD) rather than the pod-network
 
 Permitted connectivity analyzed in primary UDN blue:
 0.0.0.0-255.255.255.255[External] => blue[udn]/vm-a[VirtualMachine] : All Connections

--- a/test_outputs/connlist/udn_and_vms_test_2_connlist_output.txt
+++ b/test_outputs/connlist/udn_and_vms_test_2_connlist_output.txt
@@ -1,3 +1,5 @@
+Permitted connectivity analyzed in Pod network:
+all allowed connections utilize alternative network interfaces ((C)UDN/NAD) rather than the pod-network
 
 Permitted connectivity analyzed in primary UDN blue:
 0.0.0.0-255.255.255.255[External] => blue[udn]/vm-a[VirtualMachine] : All Connections

--- a/test_outputs/connlist/udn_and_vms_test_5_connlist_output.txt
+++ b/test_outputs/connlist/udn_and_vms_test_5_connlist_output.txt
@@ -1,3 +1,5 @@
+Permitted connectivity analyzed in Pod network:
+all allowed connections utilize alternative network interfaces ((C)UDN/NAD) rather than the pod-network
 
 Permitted connectivity analyzed in primary UDN foo:
 0.0.0.0-255.255.255.255[External] => foo[udn]/fedora-apricot-pike-81[VirtualMachine] : All Connections

--- a/test_outputs/connlist/udn_test_1_connlist_output.txt
+++ b/test_outputs/connlist/udn_test_1_connlist_output.txt
@@ -1,3 +1,5 @@
+Permitted connectivity analyzed in Pod network:
+all allowed connections utilize alternative network interfaces ((C)UDN/NAD) rather than the pod-network
 
 Permitted connectivity analyzed in primary UDN blue:
 0.0.0.0-255.255.255.255[External] => blue[udn]/webserver[Pod] : All Connections

--- a/test_outputs/connlist/udn_test_2_connlist_output.txt
+++ b/test_outputs/connlist/udn_test_2_connlist_output.txt
@@ -1,3 +1,5 @@
+Permitted connectivity analyzed in Pod network:
+all allowed connections utilize alternative network interfaces ((C)UDN/NAD) rather than the pod-network
 
 Permitted connectivity analyzed in primary UDN blue:
 0.0.0.0-255.255.255.255[External] => blue[udn]/webserver[Pod] : All Connections

--- a/test_outputs/connlist/udn_with_ingress_controller_connlist_output.txt
+++ b/test_outputs/connlist/udn_with_ingress_controller_connlist_output.txt
@@ -1,3 +1,5 @@
+Permitted connectivity analyzed in Pod network:
+all allowed connections utilize alternative network interfaces ((C)UDN/NAD) rather than the pod-network
 
 Permitted connectivity analyzed in primary UDN green:
 0.0.0.0-255.255.255.255[External] => green[udn]/app[Pod] : All Connections

--- a/test_outputs/connlist/udn_with_ingress_controller_two_pods_connlist_output.txt
+++ b/test_outputs/connlist/udn_with_ingress_controller_two_pods_connlist_output.txt
@@ -1,3 +1,5 @@
+Permitted connectivity analyzed in Pod network:
+all allowed connections utilize alternative network interfaces ((C)UDN/NAD) rather than the pod-network
 
 Permitted connectivity analyzed in primary UDN green:
 0.0.0.0-255.255.255.255[External] => green[udn]/app[Pod] : All Connections

--- a/test_outputs/connlist/udn_with_vm_and_ingress_controller_connlist_output.txt
+++ b/test_outputs/connlist/udn_with_vm_and_ingress_controller_connlist_output.txt
@@ -1,3 +1,5 @@
+Permitted connectivity analyzed in Pod network:
+all allowed connections utilize alternative network interfaces ((C)UDN/NAD) rather than the pod-network
 
 Permitted connectivity analyzed in primary UDN green:
 0.0.0.0-255.255.255.255[External] => green[udn]/vm-a[VirtualMachine] : All Connections


### PR DESCRIPTION
#618 
This PR improves the connlist text output by adding support for multi-network environments. When no pod-network connections are present and multiple networks are enabled, an explanatory message is now included to clarify that all allowed connections utilize alternative interfaces ((C)UDN/NAD).
Key changes:

- Added `multipleNetworksEnabled` flag to `formatText`
- Refactored `writeFullConnlistTxtOutput` into a method
- Injected explanatory note when applicable
- Updated test outputs to reflect new behavior